### PR TITLE
Fiix: use stack name for function view link href

### DIFF
--- a/packages/console/src/App/Stage/Functions/index.tsx
+++ b/packages/console/src/App/Stage/Functions/index.tsx
@@ -185,7 +185,7 @@ function StackItem(props: { stack: StackInfo }) {
           .map((r) => (
             <Function
               key={c.addr + r.route}
-              to={`${r.fn!.stack}/${r.fn!.node}`}
+              to={`${stack.info.StackName}/${r.fn!.node}`}
             >
               <Stack space="sm">
                 <FunctionName>{r.route}</FunctionName>


### PR DESCRIPTION
Relates to https://github.com/serverless-stack/serverless-stack/issues/1591

Just a suggestion, I don't know if this would affect other components