### PR TITLE
Added custom 'execute' method to the 'createGQLHandler' method's 'HandlerConfig'

### DIFF
--- a/packages/node/src/graphql/index.ts
+++ b/packages/node/src/graphql/index.ts
@@ -1,3 +1,4 @@
+import { execute as defaultExecuteFn } from "graphql";
 import {
   ExecutionContext,
   FormatPayloadParams,
@@ -25,6 +26,10 @@ type HandlerConfig<C> = {
     context: Context;
     execution: ExecutionContext;
   }) => Promise<C>;
+  execute?: (
+    execute: typeof defaultExecuteFn,
+    ...args: unknown[]
+  ) => ReturnType<typeof defaultExecuteFn>;
 } & (
   | { schema: GraphQLSchema }
   | {
@@ -77,6 +82,7 @@ export function createGQLHandler<T>(config: HandlerConfig<T>) {
         }
         return undefined;
       },
+      ...(config.execute && { execute: config.execute }),
     });
     if (result.type === "RESPONSE") {
       return {


### PR DESCRIPTION
This will allow us to incorporate plugins like [this](https://pothos-graphql.dev/docs/plugins/authz), which need to [wrap the execute function similar when calling graphql-helix](https://github.com/hayes/pothos/blob/35f123da076fda2575c17da181680695ac9dddf9/packages/plugin-authz/tests/example/server.ts). 

