### PR TITLE
Resources/config: Set ConfigType interface properties readonly

### DIFF
--- a/packages/resources/src/Config.ts
+++ b/packages/resources/src/Config.ts
@@ -19,12 +19,9 @@ export function codegenTypes() {
     import "@serverless-stack/node/config";
     declare module "@serverless-stack/node/config" {
     export interface ConfigType {
-      ${[
-        "APP",
-        "STAGE",
-        ...Parameter.getAllNames(),
-        ...Secret.getAllNames()
-      ].map((p) => `${p}: string;`).join("\n")}
+      ${["APP", "STAGE", ...Parameter.getAllNames(), ...Secret.getAllNames()]
+        .map((p) => `readonly ${p}: string;`)
+        .join("\n")}
     }
   }`
   );

--- a/packages/resources/src/Config.ts
+++ b/packages/resources/src/Config.ts
@@ -19,9 +19,12 @@ export function codegenTypes() {
     import "@serverless-stack/node/config";
     declare module "@serverless-stack/node/config" {
     export interface ConfigType {
-      ${["APP", "STAGE", ...Parameter.getAllNames(), ...Secret.getAllNames()]
-        .map((p) => `readonly ${p}: string;`)
-        .join("\n")}
+      ${[
+        "APP",
+        "STAGE",
+        ...Parameter.getAllNames(),
+        ...Secret.getAllNames()
+      ].map((p) => `readonly ${p}: string;`).join("\n")}
     }
   }`
   );


### PR DESCRIPTION
The Config object performs the SDK calls to fetch Parameters and Secrets as a Lambda starts.

Setting the interface properties will discourage the changing of the Config.MY_PARAM values during runtime of the lambda.

If someone were to inadvertently perform:
`Config.MY_PARAM = "someNewValue"`
The Config values would be incorrect on subsequent invocations of the Lambda's lifecycle.

This change will prevent changing these values at compile time of the project.