### PR TITLE
Feature/add optional access_type prop to oauth adapter

### DIFF
--- a/packages/node/src/auth/adapter/oauth.ts
+++ b/packages/node/src/auth/adapter/oauth.ts
@@ -22,7 +22,7 @@ export interface OauthBasicConfig {
    */
   scope: string;
   prompt?: string;
-  offline_access?: 'true' | 'false';
+  access_type?: 'online' | 'offline';
   /**
    * onSuccess callback when the oauth flow is successful. Will provide tokenset
    */
@@ -62,7 +62,7 @@ export const OauthAdapter = /* @__PURE__ */ createAdapter(
           code_challenge_method: "S256",
           state,
           prompt: config.prompt,
-          offline_access: config.offline_access
+          access_type: config.access_type
         });
 
         const expires = new Date(Date.now() + 1000 * 30).toUTCString();

--- a/packages/node/src/auth/adapter/oauth.ts
+++ b/packages/node/src/auth/adapter/oauth.ts
@@ -22,6 +22,7 @@ export interface OauthBasicConfig {
    */
   scope: string;
   prompt?: string;
+  offline_access?: 'true' | 'false';
   /**
    * onSuccess callback when the oauth flow is successful. Will provide tokenset
    */
@@ -61,6 +62,7 @@ export const OauthAdapter = /* @__PURE__ */ createAdapter(
           code_challenge_method: "S256",
           state,
           prompt: config.prompt,
+          offline_access: config.offline_access
         });
 
         const expires = new Date(Date.now() + 1000 * 30).toUTCString();


### PR DESCRIPTION
Hi guys,

In order to receive a refreshtoken from google using OAuth2 you're required to add the `access_type` queryparam to the google oauth redirect url.

This PR is doing just that.

I've set the `access_type` type to the exact values: `'online' | 'offline'` I can also change it to just a `string` if that's preferred.

Kind regards