### PR TITLE
allow lambda function to have "." in its filename

### DIFF
--- a/packages/core/src/runtime/handler/node.ts
+++ b/packages/core/src/runtime/handler/node.ts
@@ -77,7 +77,7 @@ function getModuleManager(srcPath: string): ModuleManager {
 export const NodeHandler: Definition<Bundle> = opts => {
   const dir = path.dirname(opts.handler);
   const ext = path.extname(opts.handler);
-  const base = path.basename(opts.handler).split(".")[0];
+  const base = path.basename(opts.handler).split('.').slice(0, -1).join('.');
   const file = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"]
     .map(ext => path.join(dir, base + ext))
     .find(file => {


### PR DESCRIPTION
Fixes an issue where a lambda filename is "x.lambda.ts"

Currently, it fails to locate the lambda file since it looks for `x.ts` instead of `x.lambda.ts`