### PR TITLE
Fix #2192 build logging and adds Kotlin file watch support

### DIFF
--- a/packages/core/src/runtime/handler/definition.ts
+++ b/packages/core/src/runtime/handler/definition.ts
@@ -70,11 +70,11 @@ export function buildAsync(opts: Opts, cmd: Command) {
     let buffer = "";
     proc.stdout?.on("data", (data) => {
       buffer += data;
-      isDebug && logger.debug(data);
+      isDebug && process.stdout.write(data);
     });
     proc.stderr?.on("data", (data) => {
       buffer += data;
-      isDebug && logger.debug(data);
+      isDebug && process.stderr.write(data);
     });
     // Note: in the case of Java runtime, if gradle is not found,
     // "on error" will get called. "on exit" will not get called.

--- a/packages/core/src/runtime/handler/java.ts
+++ b/packages/core/src/runtime/handler/java.ts
@@ -36,8 +36,9 @@ export const JavaHandler: Definition<Bundle> = opts => {
     args: [
       buildTask,
       `-Dorg.gradle.project.buildDir=${target}`,
-      `-Dorg.gradle.logging.level=${process.env.DEBUG ? "debug" : "lifecycle"}`,
+      ...(process.env.GRADLE_LOGGING_LEVEL ? [`-Dorg.gradle.logging.level=${process.env.GRADLE_LOGGING_LEVEL}`] : []),
     ],
+
     env: {},
   };
 

--- a/packages/core/src/runtime/handler/java.ts
+++ b/packages/core/src/runtime/handler/java.ts
@@ -110,6 +110,7 @@ export const JavaHandler: Definition<Bundle> = opts => {
     watcher: {
       include: [
         path.join(opts.srcPath, "**/*.java"),
+        path.join(opts.srcPath, "**/*.kt"),
         path.join(opts.srcPath, "**/*.gradle"),
       ],
       ignore: [],


### PR DESCRIPTION
Fixes #2192 

Also splits gradle logging level out from the DEBUG flag and requier explicit use of a GRADLE_LOGGING_LEVEL environment variable. Otherwise this was always overriding any gradle logging level set by the user in GRADLE_HOME, as well as making the gradle logs very verbose when DEBUG is set to enable _any_ log outputs. 

In the future it would be good to have a command line option to enable build logs to be logged/displayed.

Third change is to also enable watching for Kotlin files as well as Java files to allow change watching/compilation to work.
