### PR TITLE
examples/kinesisstream: update incorrect lambda paths

### DIFF
--- a/examples/kinesisstream/stacks/MyStack.ts
+++ b/examples/kinesisstream/stacks/MyStack.ts
@@ -4,8 +4,8 @@ export function MyStack({ stack }: StackContext) {
   // create a kinesis stream
   const stream = new KinesisStream(stack, "Stream", {
     consumers: {
-      consumer1: "consumer1.handler",
-      consumer2: "consumer2.handler",
+      consumer1: "functions/consumer1.handler",
+      consumer2: "functions/consumer2.handler",
     },
   });
 


### PR DESCRIPTION
I tried this example (SST version: 1.18.3), and got the following error:
```bash
==========================
 Starting Live Lambda Dev
==========================


Cannot find a handler file for "consumer1.handler"
```
I think my change fixes this. The lambda in the API GW has the "functions/" path prefix, the KinesisStream does not.

https://github.com/serverless-stack/sst/blob/master/examples/kinesisstream/stacks/MyStack.ts#L20
