### PR TITLE
DevX improvement for SST + prisma

### DIFF
--- a/examples/prisma/stacks/MyStack.ts
+++ b/examples/prisma/stacks/MyStack.ts
@@ -4,13 +4,13 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Api, StackContext } from "@serverless-stack/resources";
 
 export function MyStack({ stack, app }: StackContext) {
+  const layerPath = ".sst/layers/prisma";
+  // Clear out the layer path
+  fs.removeSync(layerPath, { force: true, recursive: true });
+
   if (!app.local) {
     // Create a layer for production
     // This saves shipping Prisma binaries once per function
-    const layerPath = ".sst/layers/prisma";
-
-    // Clear out the layer path
-    fs.removeSync(layerPath, { force: true, recursive: true });
     fs.mkdirSync(layerPath, { recursive: true });
 
     // Copy files to the layer


### PR DESCRIPTION
While doing live-lambda development on ubuntu, I found that running `yarn start` after previously running `yarn deploy` resulted in a "query engine not found" error from Prisma. This change fixes that.

![errorScreenshot](https://user-images.githubusercontent.com/4007598/203698567-c88264a8-44cb-4ffb-9ad2-18dd0a696d64.png)

