### PR TITLE
feat: Update Datadog example to latest node and extension layers

### DIFF
--- a/examples/datadog/stacks/MyStack.ts
+++ b/examples/datadog/stacks/MyStack.ts
@@ -13,8 +13,8 @@ export function MyStack({ stack, app }: StackContext) {
   if (!app.local) {
     // Configure Datadog
     const datadog = new Datadog(stack, "Datadog", {
-      nodeLayerVersion: 65,
-      extensionLayerVersion: 13,
+      nodeLayerVersion: 85,
+      extensionLayerVersion: 35,
       apiKey: process.env.DATADOG_API_KEY,
     });
 

--- a/examples/datadog/stacks/MyStack.ts
+++ b/examples/datadog/stacks/MyStack.ts
@@ -13,8 +13,8 @@ export function MyStack({ stack, app }: StackContext) {
   if (!app.local) {
     // Configure Datadog
     const datadog = new Datadog(stack, "Datadog", {
-      nodeLayerVersion: 85,
-      extensionLayerVersion: 35,
+      nodeLayerVersion: 86,
+      extensionLayerVersion: 36,
       apiKey: process.env.DATADOG_API_KEY,
     });
 


### PR DESCRIPTION
Upgrading the Datadog Nodejs Layer and Datadog Extension brings numerous new features and bugfixes. It does include breaking changes, but as this is the example file, I believe this is safe to release in any version of SST.

Only major breaking changes are upgrading the Datadog tracer & adding support for node16/node18 and ESM.

Full notes here: https://github.com/DataDog/datadog-lambda-js/#major-version-notes