### PR TITLE
Function: Modify esbuildDecorators example

### DIFF
--- a/www/docs/constructs/Function.about.md
+++ b/www/docs/constructs/Function.about.md
@@ -153,7 +153,9 @@ To use an [esbuild plugin](https://esbuild.github.io/plugins/), install the plug
 const { esbuildDecorators } = require("@anatine/esbuild-decorators");
 
 module.exports = [
-  esbuildDecorators(),
+  esbuildDecorators({
+    tsconfig: './services/tsconfig.json'
+  }),
 ];
 ```
 


### PR DESCRIPTION
Maybe someone else can weigh in if they can make this plugin work without this line but I just burned a couple hours trying to figure out why my TypeDORM code wouldn't play nice with esbuild/SST. Without specifying the tsconfig file it was using commonjs style exports (`exports.MyClass = MyClass`) on my files that had annotations which, obviously, doesn't work. 

Maybe it will work without issue if you change your root `tsconfig.json` to use `"module": "esnext"` (like the `./services/tsconfig.json` file does) but I haven't tried that and a default SST project uses `commonjs` (via the `@tsconfig/node16/tsconfig.json` extends) so I think for most people they will need to specify the `tsconfig` file in the `esbuildDecorators` config.

Hopefully this can save someone else some pain.