### PR TITLE
Removed `t.field.resolve` functions and unused functions, variables, etc when generating Pothos schema

### DIFF
--- a/packages/sst/src/pothos.ts
+++ b/packages/sst/src/pothos.ts
@@ -99,7 +99,7 @@ export async function extractSchema(opts: { schema: string }) {
                   !schemaBuilder ||
                   (callPath.node.callee.object.name !==
                     (schemaBuilder.node.id as any).name &&
-                    callPath.node.callee.property.name !== "implement")
+                    !["field", "implement"].includes(callPath.node.callee.property.name))
                 ) {
                   return;
                 }

--- a/packages/sst/src/pothos.ts
+++ b/packages/sst/src/pothos.ts
@@ -22,6 +22,11 @@ export async function generate(opts: GenerateOpts) {
   const out = path.join(path.dirname(opts.schema), "out.mjs");
 
   await fs.writeFile(out, contents, "utf8");
+
+  const transpileContents = await extractSchema({ schema: out });
+
+  await fs.writeFile(out, transpileContents, "utf8");
+
   const { schema } = await import(
     url.pathToFileURL(out).href + "?bust=" + Date.now()
   );
@@ -30,7 +35,8 @@ export async function generate(opts: GenerateOpts) {
   return schemaAsString;
 }
 
-export async function extractSchema(opts: { schema: string }) {
+
+export async function extractSchema(opts: GenerateOpts) {
   const result = await esbuild.build({
     platform: "node",
     bundle: true,


### PR DESCRIPTION
Resolves #2553

I am not well versed in babel so this is what I came up with to fix my problem. I had a variable defined in the root of a file, it was then being bundled but the import was being removed so it would error when importing it. Running esbuild + babel a second time, removes all unused variables from out.mjs. If there is a better way to do this, LMK!