### PR TITLE
RemixSite ESM support

### DIFF
--- a/packages/sst/support/remix-config-verifier/verify.cjs
+++ b/packages/sst/support/remix-config-verifier/verify.cjs
@@ -1,0 +1,69 @@
+"use strict";
+
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on("unhandledRejection", (err) => {
+  throw err;
+});
+
+const parsedArgs = parseArgs(process.argv);
+
+// Parse default config
+if (!parsedArgs["--path"]) {
+  throw new Error("--path parameter is required");
+}
+
+const configPath = parsedArgs["--path"];
+
+/*
+type RemixConfig = {
+  assetsBuildDirectory: string;
+  publicPath: string;
+  serverBuildPath: string;
+  serverBuildTarget: string;
+  server?: string;
+};
+*/
+
+const configDefaults = {
+  assetsBuildDirectory: "public/build",
+  publicPath: "/build/",
+  serverBuildPath: "build/index.js",
+  serverBuildTarget: "node-cjs",
+};
+
+// Load config
+const userConfig = require(configPath);
+const config = {
+  ...configDefaults,
+  ...userConfig,
+};
+
+// Validate config
+Object.keys(configDefaults).forEach((key) => {
+  const k = key;
+  if (config[k] !== configDefaults[k]) {
+    console.log("");
+    console.error(
+      `RemixSite: remix.config.js "${key}" must be "${configDefaults[k]}".`
+    );
+    console.log("");
+    process.exit(1);
+  }
+});
+
+function parseArgs(arrArgs) {
+  return arrArgs.slice(2).reduce((acc, key, ind, self) => {
+    if (key.startsWith("--")) {
+      if (self[ind + 1] && self[ind + 1].startsWith("-")) {
+        acc[key] = null;
+      } else if (self[ind + 1]) {
+        acc[key] = self[ind + 1];
+      } else if (!self[ind + 1]) {
+        acc[key] = null;
+      }
+    }
+    return acc;
+  }, {});
+}


### PR DESCRIPTION
*Work in progress*

This is my effort to get Remix working nicely in SST "drop in" mode. I'm attempting to get the Remix project running and outputting ESM, with the hope of support SST bind.

Current changes represented by PR:

- **Move the validation of the Remix configuration into a separate process.**

  Prior to this we were using a `require` statement which was breaking the build when I tried to toggle my Remix project into ESM mode via the package.json `"type": "module"` setting.