### PR TITLE
Stacks: Fixed issue where deployment would fail when stackName was overridden for site environments

### DIFF
--- a/.changeset/rude-queens-attack.md
+++ b/.changeset/rude-queens-attack.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Fixed issue where deployment would fail when stackName was overridden for site environments

--- a/packages/sst/src/stacks/deploy.ts
+++ b/packages/sst/src/stacks/deploy.ts
@@ -64,14 +64,14 @@ export async function deployMany(stacks: CloudFormationStackArtifact[]) {
           continue;
 
         deploy(stack).then((result) => {
-          results[stack.id] = result;
+          results[stack.stackName] = result;
           complete.add(stack.id);
 
           if (isFailed(result.status))
             stacks.forEach((s) => {
-              if (todo.delete(s.stackName)) {
-                complete.add(s.stackName);
-                results[s.id] = {
+              if (todo.delete(s.id)) {
+                complete.add(s.id);
+                results[s.stackName] = {
                   status: "DEPENDENCY_FAILED",
                   outputs: {},
                   errors: {},


### PR DESCRIPTION
This occurred when I was trying to upgrade from sst 1.x to sst 2.x.

When trying to deploy a stack with a static site which override the `stackName`, the following error occurs:

```
  app.stack(NdcBotStack, {stackName: `${app.stage}-ndc`})
```

```
Error: Cannot read properties of undefined (reading 'outputs')

Trace: TypeError: Cannot read properties of undefined (reading 'outputs')                 
    at deploy (file:///D:/Projects/ndc-bot/node_modules/sst/cli/commands/dev.js:186:37)   
    at process.<anonymous> (file:///D:/Projects/ndc-bot/node_modules/sst/cli/sst.js:56:17)
    at process.emit (node:events:525:35)                                                  
    at process.processEmit [as emit] (D:\Projects\ndc-bot\node_modules\signal-exit\index.js:199:34)
    at process._fatalException (node:internal/process/execution:149:25)
    at processPromiseRejections (node:internal/process/promises:288:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:96:32)
```

The issue comes down to the `SiteEnv.append` stores the `stackName`, however in `deployMany`, we return the results by `stackId`. When we try to cross-reference using `stackName`, the results are undefined.

As long as these two things are aligned, the cross-reference will work. However, changing either the stackName or id causes deployment issues for migration.