### PR TITLE
sst/future-auth: added support for domain specific cookie for the token

### DIFF
--- a/.changeset/silly-foxes-swim.md
+++ b/.changeset/silly-foxes-swim.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Setup support for root-domain specific cookie for sst_auth_token

--- a/packages/sst/src/node/future/auth/adapter/oauth.ts
+++ b/packages/sst/src/node/future/auth/adapter/oauth.ts
@@ -23,6 +23,13 @@ export interface OauthBasicConfig {
    */
   scope: string;
   prompt?: string;
+  /**
+   * The domain to set the cookie on, this allows for removing of auth cookies
+   * from the frontend. As the auth endpoint is always set on a different domain
+   * to the frontend or the api. This is optional, if not set the cookie will
+   * be set on the current domain only.
+   */
+  cookieDomain?: string;
 }
 
 export interface OauthConfig extends OauthBasicConfig {
@@ -66,6 +73,8 @@ export const OauthAdapter =
             secure: true,
             maxAge: 60 * 10,
             sameSite: "None",
+            // Set the cookie on the domain if it was provided
+            domain: config.cookieDomain,
           }
         );
         return {

--- a/packages/sst/src/node/future/auth/handler.ts
+++ b/packages/sst/src/node/future/auth/handler.ts
@@ -35,6 +35,13 @@ export function AuthHandler<
   ) => Promise<void | keyof Providers>;
   onSuccess: (input: Result) => Promise<SessionCreateInput>;
   onError: () => Promise<APIGatewayProxyStructuredResultV2>;
+  /**
+   * The domain to set the cookie on, this allows for removing of auth cookies
+   * from the frontend. As the auth endpoint is always set on a different domain
+   * to the frontend or the api. This is optional, if not set the cookie will
+   * be set on the current domain only.
+   */
+  cookieDomain?: string;
 }) {
   return ApiHandler(async (evt) => {
     const step = usePathParam("step");
@@ -215,6 +222,8 @@ export function AuthHandler<
         secure: true,
         sameSite: "None",
         httpOnly: true,
+        // Set the cookie on the domain if it was provided
+        domain: input.cookieDomain,
       });
       const { client_id, response_type, redirect_uri, state } = {
         ...useCookies(),


### PR DESCRIPTION
So the issue I'm having is that auth will be hosted on a different domain to the api and the frontend. E.g.
* Auth - `auth.example.com`
* API -  `api.example.com`
* Astro app - `example.com`

Now when we sign-out, whether that's through the api or the astro app, generally we are just removing the cookie so that any requests that comes after is no longer authenticated.

But you can't remove a cookie that was set for a specific domain, which it is currently there. So adding a `cookieDomain` when setting the cookie will make it available to all subdomains of that specified domain.

I don't really like that you have to set it for each Adapter though, so just wondering if there might be a better way of doing this instead of duplicating the preferences. Maybe adding an extra props that gets passed into the adapter with the event? Thoughts?

Other issues I see with this:
* Dev env might not be deployed at a specific domain, so won't work well with this