### PR TITLE
feat: add ViteSsrSite construct

### DIFF
--- a/.changeset/clever-comics-obey.md
+++ b/.changeset/clever-comics-obey.md
@@ -1,0 +1,6 @@
+---
+"sst": minor
+"@serverless-stack/docs": minor
+---
+
+Add ViteSsrSite construct

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Deploy Next.js, Remix, Astro, Solid, or any static site to AWS.
 - [**Remix**](https://docs.sst.dev/constructs/RemixSite)
 - [**Astro**](https://docs.sst.dev/constructs/AstroSite)
 - [**Solid**](https://docs.sst.dev/constructs/SolidStartSite)
+- [**Vite SSR**](https://docs.sst.dev/constructs/ViteSsrSite)
 - [**Static site**](https://docs.sst.dev/constructs/StaticSite)
 
 ### Add any backend feature

--- a/packages/sst/src/cli/commands/bind.ts
+++ b/packages/sst/src/cli/commands/bind.ts
@@ -12,6 +12,7 @@ const SITE_CONFIG = {
   AstroSite: "astro.config",
   RemixSite: "remix.config",
   SolidStartSite: "vite.config",
+  ViteSsrSite: "vite.config",
   StaticSite: "vite.config",
   SlsNextjsSite: "next.config",
 };

--- a/packages/sst/src/config.ts
+++ b/packages/sst/src/config.ts
@@ -181,7 +181,8 @@ export namespace Config {
           c.type === "AstroSite" ||
           c.type === "NextjsSite" ||
           c.type === "RemixSite" ||
-          c.type === "SolidStartSite"
+          c.type === "SolidStartSite" ||
+          c.type === "ViteSsrSite" 
       )
       .filter((c) => c.data.secrets.includes(key));
     const siteDataPlaceholder = siteData.filter(

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -91,7 +91,7 @@ import {
 import { useProject } from "../project.js";
 
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
-type SsrSiteType = "NextjsSite" | "RemixSite" | "AstroSite" | "SolidStartSite";
+type SsrSiteType = "NextjsSite" | "RemixSite" | "AstroSite" | "SolidStartSite" | "ViteSsrSite";
 
 export type SsrBuildConfig = {
   typesPath: string;

--- a/packages/sst/src/constructs/ViteSsrSite.ts
+++ b/packages/sst/src/constructs/ViteSsrSite.ts
@@ -1,0 +1,137 @@
+import { Architecture, Function as CdkFunction } from "aws-cdk-lib/aws-lambda";
+import { Construct } from "constructs";
+import esbuild from "esbuild";
+import type { BuildOptions } from "esbuild";
+import fs from "fs";
+import path from "path";
+import { SsrSite, SsrSiteProps } from "./SsrSite.js";
+import { Function } from "./Function.js";
+import { EdgeFunction } from "./EdgeFunction.js";
+
+export interface ViteSsrSiteProps extends SsrSiteProps {
+  serverHandler: {
+    path: string;
+    esbuild?: BuildOptions;
+  };
+}
+
+export class ViteSsrSite extends SsrSite {
+  protected declare props: ViteSsrSiteProps & {
+    path: Exclude<ViteSsrSiteProps["path"], undefined>;
+    runtime: Exclude<ViteSsrSiteProps["runtime"], undefined>;
+    timeout: Exclude<ViteSsrSiteProps["timeout"], undefined>;
+    memorySize: Exclude<ViteSsrSiteProps["memorySize"], undefined>;
+    waitForInvalidation: Exclude<
+      ViteSsrSiteProps["waitForInvalidation"],
+      undefined
+    >;
+  };
+
+  constructor(scope: Construct, id: string, props?: ViteSsrSiteProps) {
+    super(scope, id, {
+      ...props,
+    });
+  }
+
+  protected initBuildConfig() {
+    return {
+      typesPath: ".",
+      serverBuildOutputFile: "dist/index.mjs",
+      clientBuildOutputDir: "dist/client",
+      clientBuildVersionedSubDir: "dist/client/assets",
+    };
+  }
+
+  protected validateBuildOutput() {
+    const { serverHandler } = this.props;
+
+    const input = path.join(this.props.path, serverHandler.path);
+    const output = path.join(this.props.path, "dist", "index.mjs");
+
+    esbuild.buildSync({
+      keepNames: true,
+      bundle: true,
+      sourcemap: "inline",
+      platform: "node",
+      target: "esnext",
+      metafile: true,
+      format: "esm",
+      logLevel: "silent",
+      outfile: output,
+      entryPoints: [input],
+      ...(serverHandler.esbuild ?? {}),
+    });
+
+    const serverDir = path.join(this.props.path, "dist/server");
+    const clientDir = path.join(this.props.path, "dist/client");
+    if (!fs.existsSync(serverDir) || !fs.existsSync(clientDir)) {
+      throw new Error(
+        `Build output inside "dist/" does not contain the "server" and "client" folders. Make sure vite-plugin-ssr is enabled in your Vite app.`
+      );
+    }
+
+    super.validateBuildOutput();
+  }
+
+  protected createFunctionForRegional(): CdkFunction {
+    const {
+      runtime,
+      timeout,
+      memorySize,
+      permissions,
+      environment,
+      nodejs,
+      bind,
+      cdk,
+    } = this.props;
+
+    const fn = new Function(this, 'server', {
+      description: "Server handler",
+      handler: path.join(this.props.path, "dist", "index.handler"),
+      logRetention: "three_days",
+      runtime,
+      memorySize,
+      timeout,
+      nodejs: {
+        format: "esm",
+        ...nodejs,
+      },
+      bind,
+      environment,
+      permissions,
+      ...cdk?.server,
+      architecture:
+        cdk?.server?.architecture === Architecture.ARM_64 ? "arm_64" : "x86_64",
+    });
+    fn._doNotAllowOthersToBind = true;
+
+    return fn;
+  }
+
+  protected createFunctionForEdge(): EdgeFunction {
+    const {
+      runtime,
+      timeout,
+      memorySize,
+      bind,
+      permissions,
+      environment,
+      nodejs,
+    } = this.props;
+
+    return new EdgeFunction(this, 'server', {
+      scopeOverride: this,
+      handler: path.join(this.props.path, "dist", "index.handler"),
+      runtime,
+      timeout,
+      memorySize,
+      bind,
+      environment,
+      permissions,
+      nodejs: {
+        format: "esm",
+        ...nodejs,
+      },
+    });
+  }
+}

--- a/packages/sst/src/constructs/ViteSsrSite.tsdoc.ts
+++ b/packages/sst/src/constructs/ViteSsrSite.tsdoc.ts
@@ -1,0 +1,2 @@
+export * from "./ViteSsrSite.js";
+export * from "./SsrSite.js";

--- a/packages/sst/src/constructs/index.ts
+++ b/packages/sst/src/constructs/index.ts
@@ -22,6 +22,7 @@ export * from "./NextjsSite.js";
 export * from "./RemixSite.js";
 export * from "./SolidStartSite.js";
 export * from "./StaticSite.js";
+export * from "./ViteSsrSite.js";
 export * from "./util/size.js";
 export * from "./util/duration.js";
 export * from "./util/permission.js";

--- a/www/docs/constructs/ViteSsrSite.about.md
+++ b/www/docs/constructs/ViteSsrSite.about.md
@@ -125,7 +125,7 @@ By default, the Vite app server is deployed to a single region defined in your `
 
 You can enable edge like this:
 
-```ts
+```ts {6}
 const site = new ViteSsrSite(stack, "Site", {
   path: "my-vite-ssr-app/",
   serverHandler: {
@@ -145,7 +145,7 @@ We recommend you to deploy to a single region when unsure.
 
 You can configure the website with a custom domain hosted either on [Route 53](https://aws.amazon.com/route53/) or [externally](#configuring-externally-hosted-domain).
 
-```js {5}
+```ts {6}
 const site = new ViteSsrSite(stack, "Site", {
   path: "my-vite-ssr-app/",
   serverHandler: {
@@ -159,7 +159,7 @@ Note that visitors to the `http://` URL will be redirected to the `https://` URL
 
 You can also configure an alias domain to point to the main domain. For example, to setup `www.my-app.com` redirecting to `my-app.com`:
 
-```js {5}
+```ts {8}
 const site = new ViteSsrSite(stack, "Site", {
   path: "my-vite-ssr-app/",
   serverHandler: {
@@ -180,7 +180,7 @@ To expose environment variables to your Vite application you should utilise the 
 
 Imagine you have an API created using the [`Api`](../constructs/Api.md) construct, and you want to fetch data from the API. You'd pass the API's endpoint to your Vite app.
 
-```ts {7-9}
+```ts {10-12}
 const api = new Api(stack, "Api", {
   // ...
 });
@@ -273,7 +273,7 @@ Since the `ViteSsrSite` construct deploys your Vite app to your AWS account, it'
 
 Imagine you have a DynamoDB table created using the [`Table`](../constructs/Table.md) construct, and you want to fetch data from the Table.
 
-```ts {12}
+```ts {15}
 const table = new Table(stack, "Table", {
   // ...
 });
@@ -301,7 +301,7 @@ You can configure the website with a custom domain hosted either on [Route 53](h
 
 #### Using the basic config (Route 53 domains)
 
-```js {3}
+```ts {6}
 new ViteSsrSite(stack, "Site", {
   path: "my-vite-ssr-app",
   serverHandler: {
@@ -313,7 +313,7 @@ new ViteSsrSite(stack, "Site", {
 
 #### Redirect www to non-www (Route 53 domains)
 
-```js {3-6}
+```ts {6-9}
 new ViteSsrSite(stack, "Site", {
   path: "my-vite-ssr-app",
   serverHandler: {
@@ -328,7 +328,7 @@ new ViteSsrSite(stack, "Site", {
 
 #### Configuring domains across stages (Route 53 domains)
 
-```js {3-7}
+```ts {6-10}
 new ViteSsrSite(stack, "Site", {
   path: "my-vite-ssr-app",
   serverHandler: {
@@ -394,7 +394,7 @@ new route53.AaaaRecord(stack, "AlternateAAAARecord", recordProps);
 
 #### Importing an existing certificate (Route 53 domains)
 
-```js {8}
+```js {11}
 import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
 
 new ViteSsrSite(stack, "Site", {
@@ -417,7 +417,7 @@ Note that, the certificate needs be created in the `us-east-1`(N. Virginia) regi
 
 If you have multiple hosted zones for a given domain, you can choose the one you want to use to configure the domain.
 
-```js {8-11}
+```js {11-14}
 import { HostedZone } from "aws-cdk-lib/aws-route53";
 
 new ViteSsrSite(stack, "Site", {
@@ -439,7 +439,7 @@ new ViteSsrSite(stack, "Site", {
 
 #### Configuring externally hosted domain
 
-```js {5-11}
+```js {8-14}
 import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
 
 new ViteSsrSite(stack, "Site", {
@@ -463,7 +463,7 @@ Also note that you can also migrate externally hosted domains to Route 53 by [fo
 
 ### Configuring server function
 
-```js {3-4}
+```js {6-7}
 new ViteSsrSite(stack, "Site", {
   path: "my-vite-ssr-app",
   serverHandler: {
@@ -478,7 +478,7 @@ new ViteSsrSite(stack, "Site", {
 
 #### Using an existing S3 Bucket
 
-```js {5-7}
+```js {8-10}
 import * as s3 from "aws-cdk-lib/aws-s3";
 
 new ViteSsrSite(stack, "Site", {

--- a/www/docs/constructs/ViteSsrSite.about.md
+++ b/www/docs/constructs/ViteSsrSite.about.md
@@ -1,0 +1,567 @@
+The `ViteSsrSite` construct is a higher level CDK construct that makes it easy to create a Vite SSR app. It provides a simple way to build and deploy the app to AWS:
+
+- The browser build and public static assets are deployed to an S3 Bucket, and served out from a CloudFront CDN for fast content delivery.
+- The app server is deployed to Lambda. You can deploy to Lambda@Edge instead if the `edge` flag is enabled. Read more about [Single region vs Edge](#single-region-vs-edge).
+- It enables you to [configure custom domains](#custom-domains) for the website URL.
+- It also enable you to [automatically set the environment variables](#environment-variables) for your Vite app directly from the outputs in your SST app.
+- It provides a simple interface to [grant permissions](#using-aws-services) for your app to access AWS resources.
+
+## Quick Start
+
+1. If you are creating a new Vite SSR app, run `create vite-plugin-ssr` from the root of your SST app.
+
+```bash
+pnpm create vite-plugin-ssr
+```
+
+After the Vite app is created, your SST app structure should look like:
+
+```bash
+my-sst-app
+├─ sst.json
+├─ services
+├─ stacks
+└─ my-vite-ssr-app     <-- new Vite app
+   ├─ pages
+   ├─ renderer
+   ├─ server
+   └─ vite.config.ts
+```
+
+You can now jump to step 3 to complete the rest of the step.
+
+2. If you have an existing Vite SSR app, move the app to the root of your SST app. Your SST app structure should look like:
+
+```bash
+my-sst-app
+├─ sst.json
+├─ services
+├─ stacks
+└─ my-vite-ssr-app     <-- new Vite app
+   ├─ pages
+   ├─ renderer
+   ├─ server
+   └─ vite.config.ts
+```
+
+3. Update your server handler to use Lambda format. Make sure to export **handler** function because we use it internally. Here's an example:
+
+```typescript
+import serverlessExpress from "@vendia/serverless-express";
+import express from "express";
+import { renderPage } from "vite-plugin-ssr";
+
+const app = express();
+
+app.use(express.static(`${__dirname}/../dist/client`));
+
+app.get("*", async (req, res, next) => {
+  const { httpResponse } = await renderPage({
+    urlOriginal: req.originalUrl,
+  });
+
+  if (!httpResponse) {
+    return next();
+  }
+
+  const { statusCode, contentType, body } = httpResponse;
+
+  res.status(statusCode).type(contentType).send(body);
+});
+
+export const handler = serverlessExpress({ app });
+```
+
+4. Go into your Vite app, and add the `sst env` command to your Vite application's `package.json`. `sst env` enables you to [automatically set the environment variables](#environment-variables) for your Vite app directly from the outputs in your SST app.
+
+Update the package.json scripts for your Vite application.
+
+```diff
+  "scripts": {
+-   "dev": "vite",
++   "dev": "sst env vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+```
+
+5. Add the `ViteSsrSite` construct to an existing stack in your SST app. You can also create a new stack for the app.
+
+```ts
+import { ViteSsrSite, StackContext } as sst from "sst/constructs";
+
+export default function MyStack({ stack }: StackContext) {
+
+  // ... existing constructs
+
+  // Create the Vite SSR site
+  const site = new ViteSsrSite(stack, "Site", {
+    path: "my-vite-ssr-app/",
+    serverHandler: {
+      path: "server/index.ts",
+    },
+  });
+
+  // Add the site's URL to stack output
+  stack.addOutputs({
+    URL: site.url || "localhost",
+  });
+}
+```
+
+When you are building your SST app, `ViteSsrSite` will invoke `npm build` inside the Vite app directory. Make sure `path` is pointing to the your Vite app and `serverHandler.path` is to pointing to your Lambda handler.
+
+We also added the site's URL to the stack output. After the deploy succeeds, the URL will be printed out in the terminal. Note that during development, the site is not deployed. You should run the site locally. In this case, `site.url` is `undefined`. [Read more about how environment variables work during development](#while-developing).
+
+:::tip
+The site is not deployed when running `sst dev`. [Run the site locally while developing.](#while-developing)
+:::
+
+## Single region vs edge
+
+There are two ways you can deploy the Vite app to your AWS account.
+
+By default, the Vite app server is deployed to a single region defined in your `sst.json` or passed in via the `--region` flag. Alternatively, you can choose to deploy to the edge. When deployed to the edge, loaders/actions are running on edge location that is physically closer to the end user. In this case, the app server is deployed to AWS Lambda@Edge.
+
+You can enable edge like this:
+
+```ts
+const site = new ViteSsrSite(stack, "Site", {
+  path: "my-vite-ssr-app/",
+  serverHandler: {
+    path: "server/index.ts",
+  },
+  edge: true,
+});
+```
+
+Note that, in the case you have a centralized database, Edge locations are often far away from your database. If you are quering your database in your loaders/actions, you might experience much longer latency when deployed to the edge.
+
+:::info
+We recommend you to deploy to a single region when unsure.
+:::
+
+## Custom domains
+
+You can configure the website with a custom domain hosted either on [Route 53](https://aws.amazon.com/route53/) or [externally](#configuring-externally-hosted-domain).
+
+```js {5}
+const site = new ViteSsrSite(stack, "Site", {
+  path: "my-vite-ssr-app/",
+  serverHandler: {
+    path: "server/index.ts",
+  },
+  customDomain: "my-app.com",
+});
+```
+
+Note that visitors to the `http://` URL will be redirected to the `https://` URL.
+
+You can also configure an alias domain to point to the main domain. For example, to setup `www.my-app.com` redirecting to `my-app.com`:
+
+```js {5}
+const site = new ViteSsrSite(stack, "Site", {
+  path: "my-vite-ssr-app/",
+  serverHandler: {
+    path: "server/index.ts",
+  },
+  customDomain: {
+    domainName: "my-app.com",
+    domainAlias: "www.my-app.com",
+  },
+});
+```
+
+## Environment variables
+
+The `ViteSsrSite` construct allows you to set the environment variables in your Vite app based on outputs from other constructs in your SST app. So you don't have to hard code the config from your backend. Let's look at how.
+
+To expose environment variables to your Vite application you should utilise the `ViteSsrSite` construct `environment` configuration property rather than an `.env` file within your Vite application root.
+
+Imagine you have an API created using the [`Api`](../constructs/Api.md) construct, and you want to fetch data from the API. You'd pass the API's endpoint to your Vite app.
+
+```ts {7-9}
+const api = new Api(stack, "Api", {
+  // ...
+});
+
+new ViteSsrSite(stack, "Site", {
+  path: "my-vite-ssr-app",
+  serverHandler: {
+    path: "server/index.ts",
+  },
+  environment: {
+    API_URL: api.url,
+  },
+});
+```
+
+Then you can access the API's URL in your server code:
+
+```ts
+console.log(process.env.API_URL);
+```
+
+Let's take look at what is happening behind the scene.
+
+#### While deploying
+
+On `sst deploy`, the Vite app server is deployed to a Lambda function, and the ViteSsrSite's `environment` values are set as Lambda function environment variables. In this case, `process.env.API_URL` will be available at runtime.
+
+If you enabled the `edge` option, the Vite app server will instead get deployed to a Lambda@Edge function. We have an issue here, AWS Lambda@Edge does not support runtime environment variables. To get around this limitation, we insert a snippet to the top of your app server:
+
+```ts
+const environment = "{{ _SST_FUNCTION_ENVIRONMENT_ }}";
+process.env = { ...process.env, ...environment };
+```
+
+And at deploy time, after the referenced resources have been created, the API in this case, a CloudFormation custom resource will update the app server's code and replace the placeholder `{{ _SST_FUNCTION_ENVIRONMENT_ }}` with the actual value:
+
+```ts
+const environment = {
+  API_URL: "https://ioe7hbv67f.execute-api.us-east-1.amazonaws.com",
+};
+process.env = { ...process.env, ...environment };
+```
+
+This will make `process.env.API_URL` available at runtime.
+
+#### While developing
+
+To use these values while developing, run `sst dev` to start the [Live Lambda Development](/live-lambda-development.md) environment.
+
+```bash
+npx sst dev
+```
+
+Then in your Vite app to reference these variables, add the [`sst env`](../packages/sst.md#sst-env) command.
+
+```json title="package.json" {2}
+"scripts": {
+  "dev": "sst env vite",
+  "build": "vite build",
+  "preview": "vite preview"
+},
+```
+
+Now you can start your Vite app as usual and it'll have the environment variables from your SST app.
+
+```bash
+npm run dev
+```
+
+There are a couple of things happening behind the scenes here:
+
+1. The `sst dev` command generates a file with the values specified by the `ViteSsrSite` construct's `environment` prop.
+2. The `sst env` CLI will traverse up the directories to look for the root of your SST app.
+3. It'll then find the file that's generated in step 1.
+4. It'll load these as environment variables before running the start command.
+
+:::note
+`sst env` only works if the Vite app is located inside the SST app or inside one of its subdirectories. For example:
+
+```
+/
+  sst.json
+  my-vite-ssr-app/
+```
+:::
+
+## Using AWS services
+
+Since the `ViteSsrSite` construct deploys your Vite app to your AWS account, it's very convenient to access other resources in your AWS account. `ViteSsrSite` provides a simple way to grant [permissions](Permissions.md) to access specific AWS resources.
+
+Imagine you have a DynamoDB table created using the [`Table`](../constructs/Table.md) construct, and you want to fetch data from the Table.
+
+```ts {12}
+const table = new Table(stack, "Table", {
+  // ...
+});
+
+new ViteSsrSite(stack, "Site", {
+  path: "my-vite-ssr-app",
+  serverHandler: {
+    path: "server/index.ts",
+  },
+  environment: {
+    TABLE_NAME: table.tableName,
+  },
+});
+
+site.attachPermissions([table]);
+```
+
+Note that we are also passing the table name into the environment, so the Vite server code can fetch the value `process.env.TABLE_NAME` when calling the DynamoDB API to query the table.
+
+## Examples
+
+### Configuring custom domains
+
+You can configure the website with a custom domain hosted either on [Route 53](https://aws.amazon.com/route53/) or [externally](#configuring-externally-hosted-domain).
+
+#### Using the basic config (Route 53 domains)
+
+```js {3}
+new ViteSsrSite(stack, "Site", {
+  path: "my-vite-ssr-app",
+  serverHandler: {
+    path: "server/index.ts",
+  },
+  customDomain: "my-app.com",
+});
+```
+
+#### Redirect www to non-www (Route 53 domains)
+
+```js {3-6}
+new ViteSsrSite(stack, "Site", {
+  path: "my-vite-ssr-app",
+  serverHandler: {
+    path: "server/index.ts",
+  },
+  customDomain: {
+    domainName: "my-app.com",
+    domainAlias: "www.my-app.com",
+  },
+});
+```
+
+#### Configuring domains across stages (Route 53 domains)
+
+```js {3-7}
+new ViteSsrSite(stack, "Site", {
+  path: "my-vite-ssr-app",
+  serverHandler: {
+    path: "server/index.ts",
+  },
+  customDomain: {
+    domainName:
+      scope.stage === "prod" ? "my-app.com" : `${scope.stage}.my-app.com`,
+    domainAlias: scope.stage === "prod" ? "www.my-app.com" : undefined,
+  },
+});
+```
+
+#### Configuring alternate domain names (Route 53 domains)
+
+You can specify additional domain names for the site url. Note that the certificate for these names will not be automatically generated, so the certificate option must be specified. Also note that you need to manually create the Route 53 records for the alternate domain names.
+
+```js
+import * as acm from "aws-cdk-lib/aws-certificatemanager";
+import * as route53 from "aws-cdk-lib/aws-route53";
+import * as route53Targets from "aws-cdk-lib/aws-route53-targets";
+
+// Look up hosted zone
+const hostedZone = route53.HostedZone.fromLookup(stack, "HostedZone", {
+  domainName: "domain.com",
+});
+
+// Create a certificate with alternate domain names
+const certificate = new acm.DnsValidatedCertificate(stack, "Certificate", {
+  domainName: "foo.domain.com",
+  hostedZone,
+  region: "us-east-1",
+  subjectAlternativeNames: ["bar.domain.com"],
+});
+
+// Create site
+new ViteSsrSite(stack, "Site", {
+  path: "my-vite-ssr-app",
+  serverHandler: {
+    path: "server/index.ts",
+  },
+  customDomain: {
+    domainName: "foo.domain.com",
+    alternateNames: ["bar.domain.com"],
+    cdk: {
+      hostedZone,
+      certificate,
+    },
+  },
+});
+
+// Create A and AAAA records for the alternate domain names
+const recordProps = {
+  recordName: "bar.domain.com",
+  zone: hostedZone,
+  target: route53.RecordTarget.fromAlias(
+    new route53Targets.CloudFrontTarget(site.cdk.distribution)
+  ),
+};
+new route53.ARecord(stack, "AlternateARecord", recordProps);
+new route53.AaaaRecord(stack, "AlternateAAAARecord", recordProps);
+```
+
+#### Importing an existing certificate (Route 53 domains)
+
+```js {8}
+import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
+
+new ViteSsrSite(stack, "Site", {
+  path: "my-vite-ssr-app",
+  serverHandler: {
+    path: "server/index.ts",
+  },
+  customDomain: {
+    domainName: "my-app.com",
+    cdk: {
+      certificate: Certificate.fromCertificateArn(stack, "MyCert", certArn),
+    },
+  },
+});
+```
+
+Note that, the certificate needs be created in the `us-east-1`(N. Virginia) region as required by AWS CloudFront.
+
+#### Specifying a hosted zone (Route 53 domains)
+
+If you have multiple hosted zones for a given domain, you can choose the one you want to use to configure the domain.
+
+```js {8-11}
+import { HostedZone } from "aws-cdk-lib/aws-route53";
+
+new ViteSsrSite(stack, "Site", {
+  path: "my-vite-ssr-app",
+  serverHandler: {
+    path: "server/index.ts",
+  },
+  customDomain: {
+    domainName: "my-app.com",
+    cdk: {
+      hostedZone: HostedZone.fromHostedZoneAttributes(stack, "MyZone", {
+        hostedZoneId,
+        zoneName,
+      }),
+    },
+  },
+});
+```
+
+#### Configuring externally hosted domain
+
+```js {5-11}
+import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
+
+new ViteSsrSite(stack, "Site", {
+  path: "my-vite-ssr-app",
+  serverHandler: {
+    path: "server/index.ts",
+  },
+  cutomDomain: {
+    isExternalDomain: true,
+    domainName: "my-app.com",
+    cdk: {
+      certificate: Certificate.fromCertificateArn(stack, "MyCert", certArn),
+    },
+  },
+});
+```
+
+Note that the certificate needs be created in the `us-east-1`(N. Virginia) region as required by AWS CloudFront, and validated. After the `Distribution` has been created, create a CNAME DNS record for your domain name with the `Distribution's` URL as the value. Here are more details on [configuring SSL Certificate on externally hosted domains](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html).
+
+Also note that you can also migrate externally hosted domains to Route 53 by [following this guide](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
+
+### Configuring server function
+
+```js {3-4}
+new ViteSsrSite(stack, "Site", {
+  path: "my-vite-ssr-app",
+  serverHandler: {
+    path: "server/index.ts",
+  },
+  timeout: "5 seconds",
+  memorySize: "2048 MB",
+});
+```
+
+### Advanced examples
+
+#### Using an existing S3 Bucket
+
+```js {5-7}
+import * as s3 from "aws-cdk-lib/aws-s3";
+
+new ViteSsrSite(stack, "Site", {
+  path: "my-vite-ssr-app",
+  serverHandler: {
+    path: "server/index.ts",
+  },
+  cdk: {
+    bucket: s3.Bucket.fromBucketName(stack, "Bucket", "my-bucket"),
+  },
+});
+```
+
+#### Reusing CloudFront cache policies
+
+CloudFront has a limit of 20 cache policies per AWS account. This is a hard limit, and cannot be increased. If you plan to deploy multiple Vite sites, you can have the constructs share the same cache policies by reusing them across sites.
+
+```js
+import * as cdk from "aws-cdk-lib";
+import * as cf from "aws-cdk-lib/aws-cloudfront";
+
+const serverCachePolicy = new cf.CachePolicy(stack, "ServerCache", {
+  queryStringBehavior: cf.CacheQueryStringBehavior.all(),
+  headerBehavior: cf.CacheHeaderBehavior.none(),
+  cookieBehavior: cf.CacheCookieBehavior.all(),
+  defaultTtl: cdk.Duration.days(0),
+  maxTtl: cdk.Duration.days(365),
+  minTtl: cdk.Duration.days(0),
+  enableAcceptEncodingBrotli: true,
+  enableAcceptEncodingGzip: true,
+});
+
+new ViteSsrSite(stack, "Site1", {
+  path: "my-vite-ssr-app",
+  serverHandler: {
+    path: "server/index.ts",
+  },
+  cdk: {
+    serverCachePolicy,
+  },
+});
+
+new ViteSsrSite(stack, "Sit2", {
+  path: "another-vite-ssr-app",
+  serverHandler: {
+    path: "server/index.ts",
+  },
+  cdk: {
+    serverCachePolicy,
+  },
+});
+```
+
+#### Protecting server function behind API Gateway
+
+When deployed to a single region, instead of sending the request to the server function directly, you can send the request to API Gateway and have API Gateway proxy the request to the server function. With this setup, you can use features like authorizers to protect the server function.
+
+```js
+import { Fn } from "aws-cdk-lib";
+import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
+
+const api = new Api(stack, "Api");
+
+const site = new ViteSsrSite(stack, "Site", {
+  path: "my-vite-ssr-app",
+  serverHandler: {
+    path: "server/index.ts",
+  },
+  cdk: {
+    distribution: {
+      defaultBehavior: {
+        origin: new origins.HttpOrigin(Fn.parseDomainName(api.url)),
+      },
+    },
+  },
+});
+
+api.addRoutes(stack, {
+  "ANY /{proxy+}": {
+    type: "function",
+    cdk: {
+      function: site.cdk.function,
+    },
+  },
+});
+```

--- a/www/docs/constructs/ViteSsrSite.md
+++ b/www/docs/constructs/ViteSsrSite.md
@@ -1,0 +1,11 @@
+---
+description: "Docs for the sst.ViteSsrSite construct in the sst/constructs package"
+---
+
+import About, {toc as aboutToc } from './ViteSsrSite.about.md'
+import Tsdoc, {toc as tsdocToc } from './ViteSsrSite.tsdoc.md'
+
+<About />
+<Tsdoc />
+
+export const toc = [...aboutToc, ...tsdocToc];

--- a/www/docs/index.md
+++ b/www/docs/index.md
@@ -50,6 +50,12 @@ SST makes it easy to build modern full-stack applications on AWS.
     </a>
   </li>
   <li>
+    <a href={useBaseUrl("/constructs/ViteSsrSite")}>
+      <h3>Vite SSR</h3>
+      <p>Deploy an Vite SSR app to your AWS account.</p>
+    </a>
+  </li>
+  <li>
     <a href={useBaseUrl("/constructs/StaticSite")}>
       <h3>Static sites</h3>
       <p>Deploy any static site to your AWS account.</p>

--- a/www/docs/what-is-sst.md
+++ b/www/docs/what-is-sst.md
@@ -74,6 +74,22 @@ new SolidStartSite(stack, "site", {
 
 ---
 
+### Vite SSR
+
+Or the [`ViteSsrSite`](constructs/ViteSsrSite.md) for [Vite](https://vitejs.dev) with [vite-plugin-ssr](https://vite-plugin-ssr.com).
+
+```ts
+new ViteSsrSite(stack, "site", {
+  path: "web",
+  serverHandler: {
+    path: 'app/server.ts',
+  },
+  customDomain: "my-vite-ssr-app.com",
+});
+```
+
+---
+
 ### Static sites
 
 There's also the [`StaticSite`](constructs/StaticSite.md) for any static site builder.

--- a/www/docs/what-is-sst.md
+++ b/www/docs/what-is-sst.md
@@ -82,7 +82,7 @@ Or the [`ViteSsrSite`](constructs/ViteSsrSite.md) for [Vite](https://vitejs.dev)
 new ViteSsrSite(stack, "site", {
   path: "web",
   serverHandler: {
-    path: 'app/server.ts',
+    path: 'server/index.ts',
   },
   customDomain: "my-vite-ssr-app.com",
 });

--- a/www/generate.mjs
+++ b/www/generate.mjs
@@ -128,6 +128,7 @@ app.bootstrap({
     "../packages/sst/src/constructs/AstroSite.tsdoc.ts",
     "../packages/sst/src/constructs/SolidStartSite.tsdoc.ts",
     "../packages/sst/src/constructs/RemixSite.tsdoc.ts",
+    "../packages/sst/src/constructs/ViteSsrSite.tsdoc.ts",
   ],
   tsconfig: path.resolve("../packages/sst/tsconfig.json"),
   preserveWatchOutput: true,

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -168,6 +168,7 @@ module.exports = {
         "constructs/RemixSite",
         "constructs/AstroSite",
         "constructs/SolidStartSite",
+        "constructs/ViteSsrSite",
       ],
       Database: ["constructs/RDS", "constructs/Table"],
       Api: [


### PR DESCRIPTION
This PR adds the `ViteSsrSite` construct to help deploy [Vite](https://vitejs.dev) application with [vite-plugin-ssr](http://vite-plugin-ssr.com) plugin. The construct supports multiple deployment models for the SSR Lambda and Lambda@Edge.

```tsx
import type { StackContext } from 'sst/constructs';
import { ViteSsrSite } from 'sst/constructs';

export function WebStack({ stack }: StackContext) {
  const site = new ViteSsrSite(stack, 'site', {
    path: 'web',
    serverHandler: {
      path: 'server/index.ts',
    },
    edge: true,
    customDomain: {
      domainName: 'vite-ssr-demo.sst.dev',
      domainAlias: 'sst.dev,
    },
  });

  stack.addOutputs({
    SiteUrl: site.url ?? 'localhost',
  });
}
```

## Key point

As `vite-plugin-ssr`'s [Deploy documentation](https://vite-plugin-ssr.com/deploy) says, `vite-plugin-ssr` is just server middleware, so we need to write our own SSR Lambda handlers. In the example I used `express` and `@vendia/serverless-express`.
This server handler needs the ssr mode build output of the Vite app when building. To keep the behavior of `SsrSite` as much as possible, I made the server handler build run in the `validateBuildOutput` function, but let me know if you need any modifications. (Adding hook functions like `afterBuild`, etc.)