### PR TITLE
Function: Add Support for .NET 6.0 Minimal APIs

### DIFF
--- a/packages/sst/src/runtime/handlers/dotnet.ts
+++ b/packages/sst/src/runtime/handlers/dotnet.ts
@@ -50,7 +50,7 @@ export const useDotnetHandler = Context.memo(async () => {
           ...input.environment,
           IS_LOCAL: "true",
           AWS_LAMBDA_RUNTIME_API: `localhost:${server.port}/${input.workerID}`,
-          AWS_LAMBDA_DOTNET_DEBUG_RUN_ONCE: "true",
+          AWS_LAMBDA_DOTNET_DEBUG_RUN_ONCE: isMinimalApi ? "false": "true",
         },
         cwd: input.out,
       };


### PR DESCRIPTION
Update existing dotnet handler to detect and support dotnet minimal APIs. This addresses https://github.com/serverless-stack/sst/issues/2124 and [Roadmap Item #11769369](https://github.com/orgs/serverless-stack/projects/1/views/14?pane=issue&itemId=11769369). 

Minimal APIs are able to bypass the bootstrap requirements previously required as the `AddAwsLambdaHosting` dependency injection for ASP.NET now takes care of initializing the runtime client automatically. See this [AWS Blog](https://aws.amazon.com/blogs/compute/introducing-the-net-6-runtime-for-aws-lambda/) for more details. 