### PR TITLE
fix: set header keys to be lowercase for consistency

### DIFF
--- a/.changeset/six-waves-mate.md
+++ b/.changeset/six-waves-mate.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+API Headers can have different cases based on the client, this lowercases everything to keep it consistent

--- a/packages/sst/src/node/api/index.ts
+++ b/packages/sst/src/node/api/index.ts
@@ -155,12 +155,22 @@ export function useMethod() {
 
 export function useHeaders() {
   const evt = useEvent("api");
-  return evt.headers || {};
+  // Convert header keys to all lowercase for consistency
+  if (evt.headers) {
+    const headers: Record<string, string> = {};
+    for (const [key, value] of Object.entries(evt.headers)) {
+      if (value) {
+        headers[key.toLowerCase()] = value;
+      }
+    }
+    return headers;
+  }
+  return {};
 }
 
 export function useHeader(key: string) {
   const headers = useHeaders();
-  return headers[key];
+  return headers[key.toLowerCase()];
 }
 
 export function useFormValue(name: string) {


### PR DESCRIPTION
Depending on your clients, sometimes headers are sent as either "Authorization" or "authorization", either capitalized or all lower case. Because of this, would be good to not have to make that mistake. So by default we always lowercase the header keys. 