### PR TITLE
clean: existsAsync function's arguments

### DIFF
--- a/packages/sst/src/util/fs.ts
+++ b/packages/sst/src/util/fs.ts
@@ -42,9 +42,9 @@ export function isChild(parent: string, child: string) {
   );
 }
 
-export async function existsAsync(input: string) {
+export async function existsAsync(path: string) {
   return fs
-    .access(input)
+    .access(path)
     .then(() => true)
     .catch(() => false);
 }


### PR DESCRIPTION
I thought fs accessed a file path, so I changed the argument to that.