### PR TITLE
[Draft] fix: listing of env containing newlines

### DIFF
--- a/.changeset/sweet-birds-teach.md
+++ b/.changeset/sweet-birds-teach.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+fix the listing of env vars containing newlines

--- a/packages/sst/package.json
+++ b/packages/sst/package.json
@@ -73,6 +73,7 @@
     "cross-spawn": "^7.0.3",
     "dendriform-immer-patch-optimiser": "^2.1.0",
     "dotenv": "^16.0.3",
+    "dotenv-stringify": "^3.1.0",
     "esbuild": "0.16.13",
     "express": "^4.18.2",
     "fast-jwt": "^1.6.1",

--- a/packages/sst/src/cli/commands/secrets/list.ts
+++ b/packages/sst/src/cli/commands/secrets/list.ts
@@ -12,6 +12,8 @@ export const list = (program: Program) =>
     async (args) => {
       const { Config } = await import("../../../config.js");
       const { gray } = await import("colorette");
+      // @ts-ignore
+      const { default: envStringify } = await import("dotenv-stringify");
       const { Colors } = await import("../../colors.js");
       const secrets = await Config.secrets();
       if (Object.entries(secrets).length === 0) {
@@ -20,9 +22,14 @@ export const list = (program: Program) =>
       }
       switch (args.format || "table") {
         case "env":
-          for (const [key, value] of Object.entries(secrets)) {
-            console.log(`${key}=${value.value || value.fallback}`);
-          }
+          const env = Object.fromEntries(
+            Object.entries(secrets).map(([key, { value, fallback }]) => [
+              key,
+              value || fallback,
+            ])
+          );
+
+          console.log(envStringify(env));
           break;
         case "table":
           const keys = Object.keys(secrets);


### PR DESCRIPTION
`sst secrets set` allows one to set JSON objects that include newlines as value, but `sst secrets list env` is incapable of handling such newlines. Thus, we end up with broken outputs like this: `MY_JSON={`.

I looked for a light/straightforward package that could serialize env files for us, but couldn't find anything decent.
This PR is still a draft because the best library I found still had to be fixed first: https://github.com/compwright/dotenv-stringify/pull/9.