### PR TITLE
Change authorizer function types to IFunction

### DIFF
--- a/packages/sst/src/constructs/ApiGatewayV1Api.ts
+++ b/packages/sst/src/constructs/ApiGatewayV1Api.ts
@@ -359,7 +359,7 @@ export interface ApiGatewayV1ApiLambdaTokenAuthorizer
   /**
    * Used to create the authorizer function
    */
-  function?: Fn;
+  function?: lambda.IFunction;
   /**
    * The identity source for which authorization is requested.
    */
@@ -409,7 +409,7 @@ export interface ApiGatewayV1ApiLambdaRequestAuthorizer
   /**
    * Used to create the authorizer function
    */
-  function?: Fn;
+  function?: lambda.IFunction;
   /**
    * The identity sources for which authorization is requested.
    */

--- a/packages/sst/test/constructs/ApiGatewayV1Api.test.ts
+++ b/packages/sst/test/constructs/ApiGatewayV1Api.test.ts
@@ -919,6 +919,20 @@ test("defaultAuthorizationType-lambda_token", async () => {
   hasResource(stack, "AWS::ApiGateway::Authorizer", {
     Type: "TOKEN",
     IdentitySource: "method.request.header.Authorization",
+    AuthorizerUri: {
+      "Fn::Join": [
+        "",
+        [
+          "arn:",
+          { "Fn::Select": [ 1, { "Fn::Split": [ ":", { "Fn::GetAtt": [ "FC4345940", "Arn" ], } ] } ] },
+          ":apigateway:",
+          { "Fn::Select": [ 3, { "Fn::Split": [ ":", { "Fn::GetAtt": [ "FC4345940", "Arn" ], } ] } ] },
+          ":lambda:path/2015-03-31/functions/",
+          { "Fn::GetAtt": [ "FC4345940", "Arn" ], },
+          "/invocations",
+        ],
+      ],
+    },
   });
 });
 
@@ -950,6 +964,110 @@ test("defaultAuthorizationType-lambda_request", async () => {
   hasResource(stack, "AWS::ApiGateway::Authorizer", {
     Type: "REQUEST",
     IdentitySource: "method.request.header.Authorization",
+    AuthorizerUri: {
+      "Fn::Join": [
+        "",
+        [
+          "arn:",
+          { "Fn::Select": [ 1, { "Fn::Split": [ ":", { "Fn::GetAtt": [ "FC4345940", "Arn" ], } ] } ] },
+          ":apigateway:",
+          { "Fn::Select": [ 3, { "Fn::Split": [ ":", { "Fn::GetAtt": [ "FC4345940", "Arn" ], } ] } ] },
+          ":lambda:path/2015-03-31/functions/",
+          { "Fn::GetAtt": [ "FC4345940", "Arn" ], },
+          "/invocations",
+        ],
+      ],
+    },
+  });
+});
+
+test("authorizationFunctionCurrentVersion-lambda_token", async () => {
+  const stack = new Stack(await createApp(), "stack");
+  const f = new Function(stack, "F", { handler: "test/lambda.handler" });
+  new ApiGatewayV1Api(stack, "Api", {
+    authorizers: {
+      MyAuthorizer: {
+        type: "lambda_token",
+        function: f.currentVersion,
+        identitySources: [apig.IdentitySource.header("Authorization")],
+      },
+    },
+    defaults: {
+      authorizer: "MyAuthorizer",
+    },
+    routes: {
+      "GET /": "test/lambda.handler",
+    },
+  });
+  hasResource(stack, "AWS::ApiGateway::RestApi", {
+    Name: "test-app-Api",
+  });
+  hasResource(stack, "AWS::ApiGateway::Method", {
+    AuthorizationType: "CUSTOM",
+    AuthorizerId: { Ref: "ApiMyAuthorizer6B7BC41E" },
+  });
+  hasResource(stack, "AWS::ApiGateway::Authorizer", {
+    Type: "TOKEN",
+    IdentitySource: "method.request.header.Authorization",
+    AuthorizerUri: {
+      "Fn::Join": [
+        "",
+        [
+          "arn:",
+          { "Fn::Select": [ 1, { "Fn::Split": [ ":", { "Ref": "FCurrentVersion58B8A55D207678ad7d19cf1a3a4859345c1f2a73" } ] } ] },
+          ":apigateway:",
+          { "Fn::Select": [ 3, { "Fn::Split": [ ":", { "Ref": "FCurrentVersion58B8A55D207678ad7d19cf1a3a4859345c1f2a73" } ] } ] },
+          ":lambda:path/2015-03-31/functions/",
+          { "Ref": "FCurrentVersion58B8A55D207678ad7d19cf1a3a4859345c1f2a73" },
+          "/invocations",
+        ],
+      ],
+    },
+  });
+});
+
+test("authorizationFunctionCurrentVersion-lambda_request", async () => {
+  const stack = new Stack(await createApp(), "stack");
+  const f = new Function(stack, "F", { handler: "test/lambda.handler" });
+  new ApiGatewayV1Api(stack, "Api", {
+    authorizers: {
+      MyAuthorizer: {
+        type: "lambda_request",
+        function: f.currentVersion,
+        identitySources: [apig.IdentitySource.header("Authorization")],
+      },
+    },
+    defaults: {
+      authorizer: "MyAuthorizer",
+    },
+    routes: {
+      "GET /": "test/lambda.handler",
+    },
+  });
+  hasResource(stack, "AWS::ApiGateway::RestApi", {
+    Name: "test-app-Api",
+  });
+  hasResource(stack, "AWS::ApiGateway::Method", {
+    AuthorizationType: "CUSTOM",
+    AuthorizerId: { Ref: "ApiMyAuthorizer6B7BC41E" },
+  });
+  hasResource(stack, "AWS::ApiGateway::Authorizer", {
+    Type: "REQUEST",
+    IdentitySource: "method.request.header.Authorization",
+    AuthorizerUri: {
+      "Fn::Join": [
+        "",
+        [
+          "arn:",
+          { "Fn::Select": [ 1, { "Fn::Split": [ ":", { "Ref": "FCurrentVersion58B8A55D207678ad7d19cf1a3a4859345c1f2a73" } ] } ] },
+          ":apigateway:",
+          { "Fn::Select": [ 3, { "Fn::Split": [ ":", { "Ref": "FCurrentVersion58B8A55D207678ad7d19cf1a3a4859345c1f2a73" } ] } ] },
+          ":lambda:path/2015-03-31/functions/",
+          { "Ref": "FCurrentVersion58B8A55D207678ad7d19cf1a3a4859345c1f2a73" },
+          "/invocations",
+        ],
+      ],
+    },
   });
 });
 


### PR DESCRIPTION
### Updates

- Change token authorizer function type from SST Function to CDK IFunction
- Change request authorizer function type from SST Function to CDK IFunction
- Add tests for referencing `currentVersion` when setting authorizer function on token and request authorizers

### Context

In a [recent help thread](https://discord.com/channels/983865673656705025/1113133552305975407/1113133552305975407) a user was attempting to leverage provisioned concurrency for their authorizer lambda function on an API Gateway V1 instance. This was technically doable by just referencing the authorizers `currentVersion` to ensure that a version got created that could be targeted by the provisioned concurrency configuration in Lambda and directly referenced by API Gateway.

That said, the type definitions for the authorizer functions didn't allow for using a `fn.currentVersion` which is of type `Version` and required directly passing SST's Function construct type.

Underneath the hood it looks like the CDK can accept an `IFunction` interface, which the `Version` type implements. Just switching from the concrete type to this interface seems to make Typescript happy.

https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda.Version.html
![image](https://github.com/serverless-stack/sst/assets/3394151/6e5bf17b-9f3d-49a1-b8b0-f157a0b2188a)
https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.RequestAuthorizer.html
![image](https://github.com/serverless-stack/sst/assets/3394151/f46b1fd6-07c2-4008-8f9b-2fcb6903a229)
https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.TokenAuthorizer.html
![image](https://github.com/serverless-stack/sst/assets/3394151/a089ffd9-02e0-4930-9b72-40f57a651f7e)
