### PR TITLE
apply tags via TagManager instead of tags aspect

### DIFF
--- a/.changeset/smooth-stingrays-peel.md
+++ b/.changeset/smooth-stingrays-peel.md
@@ -1,0 +1,5 @@
+---
+"sst": minor
+---
+
+Update App construct to apply Stack tags via TagManager instead of tag aspect

--- a/packages/sst/src/constructs/App.ts
+++ b/packages/sst/src/constructs/App.ts
@@ -270,8 +270,8 @@ export class App extends CDKApp {
     for (const child of this.node.children) {
       if (isStackConstruct(child)) {
         // Tag stacks
-        Tags.of(child).add("sst:app", this.name);
-        Tags.of(child).add("sst:stage", this.stage);
+        child.tags.setTag("sst:app", this.name);
+        child.tags.setTag("sst:stage", this.stage);
 
         // Set removal policy
         if (this._defaultRemovalPolicy)


### PR DESCRIPTION
This updates the App construct to apply tags via TagManager instead of the tags aspect. What that means is that it will apply the tags via the native Stack mechanism, e.g stackTags instead of adding tags to all CloudFormation resources individually. This makes the resulting stack less verbose and doesn't result in things getting tagged that aren't supported. For example, OAM Sink breaks if you apply tags since its schema is strict.

Corresponding help post: https://discord.com/channels/983865673656705025/1090816114801524857/1090816114801524857

This _should_ be a non-visible/non-breaking change, but there is the potential that certain resources support direct tagging (via `Properties.Tags`) but not indirect tagging via Stack Tag propagation.

Why is there two documented ways to do the same thing in wildly different ways? AWS.