### PR TITLE
feat: add --to option to dev so builddir can be outside project root

### DIFF
--- a/.changeset/lovely-geckos-stare.md
+++ b/.changeset/lovely-geckos-stare.md
@@ -1,5 +1,5 @@
 ---
-"sst": major
+"sst": patch
 ---
 
 add --to option to dev so builddir can be outside project root

--- a/.changeset/lovely-geckos-stare.md
+++ b/.changeset/lovely-geckos-stare.md
@@ -1,0 +1,5 @@
+---
+"sst": major
+---
+
+add --to option to dev so builddir can be outside project root

--- a/packages/sst/src/cli/commands/dev.tsx
+++ b/packages/sst/src/cli/commands/dev.tsx
@@ -6,10 +6,15 @@ export const dev = (program: Program) =>
     ["dev", "start"],
     "Work on your app locally",
     (yargs) =>
-      yargs.option("increase-timeout", {
-        type: "boolean",
-        description: "Increase function timeout",
-      }),
+      yargs
+	.option("increase-timeout", {
+          type: "boolean",
+          description: "Increase function timeout",
+	})
+	.option("to", {
+          type: "string",
+          describe: "Output directory, defaults to .sst/dist",
+	}),
     async (args) => {
       const { Colors } = await import("../colors.js");
       const { printHeader } = await import("../ui/header.js");
@@ -190,6 +195,7 @@ export const dev = (program: Program) =>
               increaseTimeout: args["increase-timeout"],
               scriptVersion,
               fn: project.stacks,
+              buildDir: args.to,
               outDir: `.sst/cdk.out`,
               mode: "dev",
             });


### PR DESCRIPTION
This makes it comatible with the build and diff command. Not writing to the project directory helps with nx caching.

Given this buildDir now surfaces about everywhere, a global setting somewhere would be nice at some point.