### PR TITLE
Feat(NextjsSite) : extend construct using factory pattern

### DIFF
--- a/packages/sst/src/constructs/Distribution.ts
+++ b/packages/sst/src/constructs/Distribution.ts
@@ -156,7 +156,11 @@ export class Distribution extends Construct {
 
     this.hostedZone = this.lookupHostedZone();
     this.certificate = this.createCertificate();
-    this.distribution = this.createDistribution();
+    this.distribution = this.createDistribution("Distribution", {
+      ...props.cdk?.distribution,
+      domainNames: this.buildDistributionDomainNames(),
+      certificate: this.certificate,
+    });
     this.createRoute53Records();
   }
 
@@ -363,16 +367,6 @@ export class Distribution extends Construct {
     return acmCertificate;
   }
 
-  private createDistribution(): CdkDistribution {
-    const { cdk } = this.props;
-
-    return new CdkDistribution(this.scope, "Distribution", {
-      ...(cdk?.distribution as CdkDistributionProps),
-      domainNames: this.buildDistributionDomainNames(),
-      certificate: this.certificate,
-    });
-  }
-
   private buildDistributionDomainNames(): string[] {
     const { customDomain } = this.props;
     const domainNames = [];
@@ -426,5 +420,13 @@ export class Distribution extends Construct {
         targetDomain: recordName,
       });
     }
+  }
+
+  /////////////////////
+  // Factory methods
+  /////////////////////
+
+  protected createDistribution(id: string, props: CdkDistributionProps): CdkDistribution {
+    return new CdkDistribution(this.scope, id, props);
   }
 }

--- a/packages/sst/src/constructs/SsrFunction.ts
+++ b/packages/sst/src/constructs/SsrFunction.ts
@@ -21,6 +21,7 @@ import {
   Code,
   FunctionOptions,
   Function as CdkFunction,
+  FunctionProps,
   FunctionUrlOptions,
 } from "aws-cdk-lib/aws-lambda";
 import { Bucket } from "aws-cdk-lib/aws-s3";
@@ -106,7 +107,7 @@ export class SsrFunction extends Construct implements SSTConstruct {
       assetBucket,
       assetKey
     );
-    this.function = this.createFunction(assetBucket, assetKey);
+    this.function = this.createServerFunction(assetBucket, assetKey);
     this.attachPermissions(props.permissions || []);
     this.bind(props.bind || []);
     this.function.node.addDependency(assetReplacer);
@@ -162,7 +163,7 @@ export class SsrFunction extends Construct implements SSTConstruct {
     this.missingSourcemap = true;
   }
 
-  private createFunction(assetBucket: string, assetKey: string) {
+  private createServerFunction(assetBucket: string, assetKey: string) {
     const {
       architecture,
       runtime,
@@ -172,7 +173,7 @@ export class SsrFunction extends Construct implements SSTConstruct {
       logRetention,
     } = this.props;
 
-    return new CdkFunction(this, `ServerFunction`, {
+    return this.createFunction(`ServerFunction`, {
       ...this.props,
       handler: handler.split(path.sep).join(path.posix.sep),
       logRetention: logRetention ?? RetentionDays.THREE_DAYS,
@@ -382,5 +383,13 @@ export class SsrFunction extends Construct implements SSTConstruct {
   /** @internal */
   public getFunctionBinding() {
     return undefined;
+  }
+
+  /////////////////////
+  // Factory methods
+  /////////////////////
+
+  protected createFunction(id: string, props: FunctionProps){
+    return new CdkFunction(this, id, props)
   }
 }

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -69,7 +69,7 @@ import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 
 import { App } from "./App.js";
 import { Stack } from "./Stack.js";
-import { Distribution, DistributionDomainProps } from "./Distribution.js";
+import { Distribution, DistributionDomainProps, DistributionProps } from "./Distribution.js";
 import { Logger } from "../logger.js";
 import { createAppContext } from "./context.js";
 import { SSTConstruct, isCDKConstruct } from "./Construct.js";
@@ -573,7 +573,7 @@ export abstract class SsrSite extends Construct implements SSTConstruct {
     let singletonOriginRequestPolicy: IOriginRequestPolicy;
 
     // Create Bucket
-    const bucket = createS3Bucket();
+    const bucket = self.createS3Bucket();
 
     // Build app
     buildApp();
@@ -683,23 +683,6 @@ export abstract class SsrSite extends Construct implements SSTConstruct {
       }
     }
 
-    function createS3Bucket() {
-      // cdk.bucket is an imported construct
-      if (cdk?.bucket && isCDKConstruct(cdk?.bucket)) {
-        return cdk.bucket as Bucket;
-      }
-
-      // cdk.bucket is a prop
-      return new Bucket(self, "S3Bucket", {
-        publicReadAccess: false,
-        blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
-        autoDeleteObjects: true,
-        removalPolicy: RemovalPolicy.DESTROY,
-        enforceSSL: true,
-        ...cdk?.bucket,
-      });
-    }
-
     function createServerFunctionForDev() {
       const role = new Role(self, "ServerFunctionRole", {
         assumedBy: new CompositePrincipal(
@@ -709,7 +692,7 @@ export abstract class SsrSite extends Construct implements SSTConstruct {
         maxSessionDuration: CdkDuration.hours(12),
       });
 
-      return new SsrFunction(self, `ServerFunction`, {
+      return self.createSsrFunction(`ServerFunction`, {
         description: "Server handler placeholder",
         bundle: path.join(__dirname, "../support/ssr-site-function-stub"),
         handler: "index.handler",
@@ -739,7 +722,7 @@ export abstract class SsrSite extends Construct implements SSTConstruct {
       if (ssrFunctions.length === 0) return;
 
       // Create warmer function
-      const warmer = new CdkFunction(self, "WarmerFunction", {
+      const warmer = self.createFunction("WarmerFunction", {
         description: "SSR warmer",
         code: Code.fromAsset(
           plan.warmerConfig?.function ??
@@ -786,7 +769,7 @@ export abstract class SsrSite extends Construct implements SSTConstruct {
     }
 
     function createCloudFrontDistribution() {
-      const distribution = new Distribution(self, "CDN", {
+      const distribution = self.createDistribution("CDN", {
         scopeOverride: self,
         customDomain,
         cdk: {
@@ -979,7 +962,7 @@ function handler(event) {
     }
 
     function createFunctionOrigin(props: FunctionOriginConfig) {
-      const fn = new SsrFunction(self, props.constructId, {
+      const fn = self.createSsrFunction(props.constructId, {
         runtime,
         timeout,
         memorySize,
@@ -1041,7 +1024,7 @@ function handler(event) {
     function createImageOptimizationFunctionOrigin(
       props: ImageOptimizationFunctionOriginConfig
     ) {
-      const fn = new CdkFunction(self, `ImageFunction`, {
+      const fn = self.createFunction(`ImageFunction`, {
         currentVersionOptions: {
           removalPolicy: RemovalPolicy.DESTROY,
         },
@@ -1559,6 +1542,45 @@ function handler(event) {
     };
   }) {
     return input;
+  }
+
+
+  /////////////////////
+  // Factory methods
+  /////////////////////
+
+  protected createFunction(id: string, props: CdkFunctionProps): CdkFunction {
+    return new CdkFunction(this, id, props)
+  }
+
+  protected createSsrFunction(id: string, props: SsrFunctionProps): SsrFunction {
+    return new SsrFunction(this, id, props);
+  }
+
+  /**
+   *  `domainNames`, `certificate`, `defaultBehavior` and `additionalBehaviors` should NOT be overwritten
+   */
+  protected createDistribution(id: string, props: DistributionProps): Distribution {
+    return new Distribution(this, id, props)
+  }
+
+  protected createS3Bucket(): Bucket {
+    const { cdk } = this.props;
+
+    // cdk.bucket is an imported construct
+    if (cdk?.bucket && isCDKConstruct(cdk?.bucket)) {
+      return cdk.bucket as Bucket;
+    }
+
+    // cdk.bucket is a prop
+    return new Bucket(this, "S3Bucket", {
+      publicReadAccess: false,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      autoDeleteObjects: true,
+      removalPolicy: RemovalPolicy.DESTROY,
+      enforceSSL: true,
+      ...cdk?.bucket,
+    });
   }
 }
 

--- a/packages/sst/test/constructs/NextjsSite.test.ts
+++ b/packages/sst/test/constructs/NextjsSite.test.ts
@@ -16,6 +16,10 @@ import {
 import { Vpc } from "aws-cdk-lib/aws-ec2";
 import * as cf from "aws-cdk-lib/aws-cloudfront";
 import { Stack, NextjsSite, NextjsSiteProps } from "../../dist/constructs";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+import { SsrFunction } from "../../dist/constructs/SsrFunction.js";
+import { Function as CdkFunction} from "aws-cdk-lib/aws-lambda";
+import { Distribution } from "../../dist/constructs/Distribution.js";
 
 const sitePath = "test/constructs/nextjs-site";
 
@@ -209,4 +213,44 @@ test("buildCloudWatchRouteName", async () => {
   expect(NextjsSite._test.buildCloudWatchRouteName("/api/[id]")).toEqual(
     "/api/id"
   );
+});
+
+/////////////////////////////
+// Test extending ()
+/////////////////////////////
+
+test("constructor: extending factory methods", async () => {
+  const mockCreateQueue = vi.fn((scope, id, props) => new Queue(scope, id, props));
+  const mockCreateDistribution = vi.fn((scope, id, props) => new Distribution(scope, id, props));
+  const mockCreateSsrFunction = vi.fn((scope, id, props) => new SsrFunction(scope, id, props));
+  const mockCreateFunction = vi.fn((scope, id, props) => new CdkFunction(scope, id, props));
+  
+  class MyNextjsSite extends NextjsSite {
+    protected createQueue(id, props) {
+      return mockCreateQueue(this, id, props);
+    }
+    protected createDistribution(id, props) {
+      return mockCreateDistribution(this, id, props);
+    }
+    protected createSsrFunction(id, props) {
+      return mockCreateSsrFunction(this, id, props);
+    }
+    protected createFunction(id, props) {
+      return mockCreateFunction(this, id, props);
+    }
+  }
+
+  const app = await createApp()
+  const stack = new Stack(app, "stack");
+  new MyNextjsSite(stack, "Site", {
+    path: sitePath,
+    buildCommand: "echo 'skip'",
+  });
+  await app.finish();
+  countResources(stack, "AWS::SQS::Queue", 1);
+  expect(mockCreateQueue).toHaveBeenCalledOnce();
+  countResources(stack, "AWS::CloudFront::Distribution", 1);
+  expect(mockCreateDistribution).toHaveBeenCalledOnce();
+  expect(mockCreateSsrFunction).toHaveBeenCalledOnce();
+  expect(mockCreateFunction).toHaveBeenCalled();
 });

--- a/www/docs/constructs/NextjsSite.about.md
+++ b/www/docs/constructs/NextjsSite.about.md
@@ -609,6 +609,41 @@ new NextjsSite(stack, "Site", {
 });
 ```
 
+#### Using custom low level constructs
+
+You can extend the `NextjsSite` by using your custom low level constructs by following [this guide](../advanced/extending-sst.md#using-custom-low-level-constructs-in-an-sst-high-level-construct).
+
+The SST construct will use your custom construct when one of the following methods is overridden
+
+```ts
+import { NextjsSite as SstNextjsSite } from 'sst/constructs'
+
+class NextjsSite extends SstNextjsSite {
+  // build SQS Queues
+  protected createQueue(id, props): Queue
+
+  // build Cloudfront Distributions
+  protected createDistribution(id, props): Distribution 
+  
+  // build sst SsrFunctions
+  protected createSsrFunction(id, props): SsrFunction 
+  
+  // build Lambda Functions
+  protected createFunction(id, props): Function 
+  
+  // Build S3 Buckets
+  protected createS3Bucket(id, props): Bucket
+
+  // Build Table (for experimental incremental static regeneration)
+  protected createTable(id, props): Table
+
+}
+```
+
+:::info
+Your extension of the SST construct must be named `NextjsSite` to prevent an error when running `sst dev`.
+:::
+
 ## Common Issues
 
 ### Next.js app built twice


### PR DESCRIPTION
resolves #3019 

The `NextjsSite` construct is an L3 construct built on top of cdk's L2 constructs (Function, Bucket, Distribution, Queue).
For teams that have customized their own L2 constructs, it would be great to be able to build a NextjsSite with these base constructs. 

This pr is a proposition to use protected factory method that give possibility to teams to extend `NextjsSite` and use their own customized constructs.
The suggested interface can be found in the tests : https://github.com/serverless-stack/sst/blob/5b8373cfeedab2d5c0fffb5a2081c26cfa491f5f/packages/sst/test/constructs/NextjsSite.test.ts#L156-L169