### PR TITLE
Fix types for api gateway v1 authorizer

### DIFF
--- a/.changeset/giant-dodos-battle.md
+++ b/.changeset/giant-dodos-battle.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Fix typings for custom authorizers in ApiGatewayV1 construct

--- a/packages/sst/src/constructs/ApiGatewayV1Api.ts
+++ b/packages/sst/src/constructs/ApiGatewayV1Api.ts
@@ -183,7 +183,10 @@ export interface ApiGatewayV1ApiProps<
     authorizer?:
       | "none"
       | "iam"
-      | (string extends AuthorizerKeys ? never : AuthorizerKeys);
+      // | (string extends AuthorizerKeys ? never : AuthorizerKeys);
+      | (string extends AuthorizerKeys
+          ? Omit<AuthorizerKeys, "none" | "iam">
+          : AuthorizerKeys);
     /**
      * An array of scopes to include in the authorization when using `user_pool` or `jwt` authorizers. These will be merged with the scopes from the attached authorizer.
      * @default []
@@ -263,7 +266,10 @@ export interface ApiGatewayV1ApiFunctionRouteProps<AuthorizerKeys = never> {
   authorizer?:
     | "none"
     | "iam"
-    | (string extends AuthorizerKeys ? never : AuthorizerKeys);
+    // | (string extends AuthorizerKeys ? never : AuthorizerKeys);
+      | (string extends AuthorizerKeys
+          ? Omit<AuthorizerKeys, "none" | "iam">
+          : AuthorizerKeys);
   authorizationScopes?: string[];
   cdk?: {
     method?: Omit<
@@ -1447,12 +1453,12 @@ export class ApiGatewayV1Api<
       };
     }
 
-    if (!this.props.authorizers || !this.props.authorizers[authorizerKey]) {
+    if (!this.props.authorizers || !this.props.authorizers[authorizerKey as string]) {
       throw new Error(`Cannot find authorizer "${authorizerKey.toString()}"`);
     }
 
     const authorizer = this.authorizersData[authorizerKey as string];
-    const authorizationType = this.props.authorizers[authorizerKey].type;
+    const authorizationType = this.props.authorizers[authorizerKey as string].type;
     if (authorizationType === "user_pools") {
       return {
         authorizationType: apig.AuthorizationType.COGNITO,


### PR DESCRIPTION
Authorizer typings seem to be incorrect in ApiGatewayV1Api

In `sst/constructs/Api.ts` the authorizer type correctly extends the `AuthorizerKeys` type to allow AuthorizerKeys to be specified as an authorizer to the function construct
https://github.com/sst/sst/blob/5fff7a6eee7309db9fd4c50e84bfb36d36f7d1e6/packages/sst/src/constructs/Api.ts#L381

```
    authorizer?:
      | "none"
      | "iam"
      | (string extends AuthorizerKeys
          ? Omit<AuthorizerKeys, "none" | "iam">
          : AuthorizerKeys);
```

However in `sst/constructs/ApiGatewayV1Api.ts` the authorizer keys can never be assigned as a string leading to incorrect typing clashes
https://github.com/sst/sst/blob/5fff7a6eee7309db9fd4c50e84bfb36d36f7d1e6/packages/sst/src/constructs/ApiGatewayV1Api.ts#L183

```
    authorizer?:
      | "none"
      | "iam"
      | (string extends AuthorizerKeys ? never : AuthorizerKeys);
```

This PR updates the v1 file to match the typings in v2