### PR TITLE
fix: astro redirects broken

### DIFF
--- a/.changeset/nice-cooks-train.md
+++ b/.changeset/nice-cooks-train.md
@@ -1,0 +1,5 @@
+---
+"astro-sst": patch
+---
+
+AstroSite: fix redirects for streaming response

--- a/packages/astro-sst/src/lib/event-mapper.ts
+++ b/packages/astro-sst/src/lib/event-mapper.ts
@@ -262,6 +262,7 @@ function convertToApigV2StreamingResult({
   responseStream = awslambda.HttpResponseStream.from(responseStream, metadata);
 
   if (!body) {
+    responseStream.write(0);
     responseStream.end();
     return;
   }


### PR DESCRIPTION
In cases where a response from Astro doesn't have a body, there's an issue where the response headers and status don't get sent to the caller. We have to call `write` before calling `end`, which I think is a quirk of the underlying runtime implementation for streaming on AWS Lambda. It doesn't appear to matter what we pass into `write`, but I stressed over it a bit (empty string was less aesthetically pleasing to me, but I don't hold a strong opinion and 0 isn't much better).