### PR TITLE
Service: Add node client and docs

### DIFF
--- a/.changeset/empty-candles-fold.md
+++ b/.changeset/empty-candles-fold.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Service: Add node client and docs

--- a/packages/sst/src/node/service/index.ts
+++ b/packages/sst/src/node/service/index.ts
@@ -1,0 +1,7 @@
+import { createProxy } from "../util/index.js";
+
+export interface ServiceResources {}
+
+export const Service =
+  /* @__PURE__ */
+  createProxy<ServiceResources>("Service");

--- a/www/docs/clients/service.md
+++ b/www/docs/clients/service.md
@@ -26,21 +26,11 @@ This module helps with accessing [`Service`](../constructs/Service.md) construct
 import { Service } from "sst/node/service";
 ```
 
-#### customDomainUrl
-
-_Type_ : <span class="mono">string</span>
-
-If the custom domain is enabled, this is the URL of the website with the custom domain.
-
-```ts
-console.log(Service.myService.customDomainUrl);
-```
-
 #### url
 
 _Type_ : <span class="mono">string</span>
 
-The CloudFront URL of the website.
+The URL of the service. If custom domain is enabled, this is the custom domain URL of the service.
 
 ```ts
 console.log(Service.myService.url);

--- a/www/docs/clients/service.md
+++ b/www/docs/clients/service.md
@@ -1,0 +1,47 @@
+---
+description: "Overview of the `service` module."
+---
+
+Overview of the `service` module in the `sst/node` package.
+
+```ts
+import { ... } from "sst/node/service"
+```
+
+The `service` module has the following exports.
+
+---
+
+## Properties
+
+The properties let you access the resources that are bound to the function.
+
+---
+
+### Service
+
+This module helps with accessing [`Service`](../constructs/Service.md) constructs.
+
+```ts
+import { Service } from "sst/node/service";
+```
+
+#### customDomainUrl
+
+_Type_ : <span class="mono">string</span>
+
+If the custom domain is enabled, this is the URL of the website with the custom domain.
+
+```ts
+console.log(Service.myService.customDomainUrl);
+```
+
+#### url
+
+_Type_ : <span class="mono">string</span>
+
+The CloudFront URL of the website.
+
+```ts
+console.log(Service.myService.url);
+```

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -234,6 +234,7 @@ module.exports = {
         "clients/config",
         "clients/queue",
         "clients/bucket",
+        "clients/service",
         "clients/graphql",
         "clients/function",
         "clients/event-bus",


### PR DESCRIPTION
This should address some [type errors](https://discord.com/channels/983865673656705025/1142284213207437453/1142284213207437453) that occur when a `Service` construct is introduced to the app