### PR TITLE
python-runtime: pin poetry dependency to fix ssl error

### DIFF
--- a/.changeset/strong-sheep-float.md
+++ b/.changeset/strong-sheep-float.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+python-runtime: pin poetry dependency to fix ssl error

--- a/packages/sst/support/python-runtime/Dockerfile.dependencies
+++ b/packages/sst/support/python-runtime/Dockerfile.dependencies
@@ -10,7 +10,7 @@ RUN yum -q list installed rsync &>/dev/null || yum install -y rsync
 RUN pip install --upgrade pip
 
 # Install pipenv and poetry so we can create a requirements.txt if we detect pipfile or poetry.lock respectively
-RUN pip install pipenv poetry
+RUN pip install pipenv poetry==1.5.1
 
 # Install the dependencies in a cacheable layer
 WORKDIR /var/dependencies


### PR DESCRIPTION
Starting Aug 18 2023 the python builds which use poetry are broken.

The cause is an update in poetry used to install the dependencies. The new release uses a new version of urllib3 which requires an SSL package not available in aws python image builds used by the sst construct (aws images).

My solution is to pin the latest poetry package works (1.5.1) while AWS does not update the building images.

This is the error I get before my fix:

```
 => [internal] load .dockerignore                                                                                           0.1s
 => => transferring context: 2B                                                                                             0.0s
 => [internal] load build definition from Dockerfile.dependencies                                                           0.1s
 => => transferring dockerfile: 1.45kB                                                                                      0.0s
 => [internal] load metadata for public.ecr.aws/sam/build-python3.8:latest                                                  5.9s
 => [internal] load build context                                                                                           0.0s
 => => transferring context: 77.53kB                                                                                        0.0s
 => [1/9] FROM public.ecr.aws/sam/build-python3.8@sha256:2a6069a6517530f0f6e680aaaaee1580468d6099d45ef059bd6439e6fe7871db   0.0s
 => CACHED [2/9] RUN yum -q list installed rsync &>/dev/null || yum install -y rsync                                        0.0s
 => CACHED [3/9] RUN pip install --upgrade pip                                                                              0.0s
 => CACHED [4/9] RUN pip install pipenv poetry                                                                              0.0s
 => CACHED [5/9] WORKDIR /var/dependencies                                                                                  0.0s
 => CACHED [6/9] COPY Pipfile* pyproject* poetry* requirements.tx[t] ./                                                     0.0s
 => CACHED [7/9] RUN if [ -f 'Pipfile' ]; then pipenv requirements > requirements.txt; else echo "Pipfile not found"; fi    0.0s
 => ERROR [8/9] RUN if [ -f 'poetry.lock' ]; then poetry export --with-credentials --format requirements.txt --output requ  0.5s
------                                                                                                                           
 > [8/9] RUN if [ -f 'poetry.lock' ]; then poetry export --with-credentials --format requirements.txt --output requirements.txt; else echo "poetry.lock not found"; fi:                                                                                           
0.401 Traceback (most recent call last):                                                                                         
0.401   File "/var/lang/lib/python3.8/site-packages/cleo/application.py", line 327, in run                                       
0.401     exit_code = self._run(io)
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/console/application.py", line 188, in _run
0.401     self._load_plugins(io)
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/console/application.py", line 354, in _load_plugins
0.401     manager.load_plugins()
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/plugins/plugin_manager.py", line 38, in load_plugins
0.401     self._load_plugin_entry_point(ep)
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/plugins/plugin_manager.py", line 76, in _load_plugin_entry_point
0.401     plugin = ep.load()  # type: ignore[no-untyped-call]
0.401   File "/var/lang/lib/python3.8/site-packages/importlib_metadata/__init__.py", line 209, in load
0.401     module = import_module(match.group('module'))
0.401   File "/var/lang/lib/python3.8/importlib/__init__.py", line 127, in import_module
0.401     return _bootstrap._gcd_import(name[level:], package, level)
0.401   File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
0.401   File "<frozen importlib._bootstrap>", line 991, in _find_and_load
0.401   File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
0.401   File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
0.401   File "<frozen importlib._bootstrap_external>", line 843, in exec_module
0.401   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
0.401   File "/var/lang/lib/python3.8/site-packages/poetry_plugin_export/plugins.py", line 7, in <module>
0.401     from poetry_plugin_export.command import ExportCommand
0.401   File "/var/lang/lib/python3.8/site-packages/poetry_plugin_export/command.py", line 10, in <module>
0.401     from poetry_plugin_export.exporter import Exporter
0.401   File "/var/lang/lib/python3.8/site-packages/poetry_plugin_export/exporter.py", line 11, in <module>
0.401     from poetry.repositories.http_repository import HTTPRepository
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/repositories/http_repository.py", line 13, in <module>
0.401     import requests
0.401   File "/var/lang/lib/python3.8/site-packages/requests/__init__.py", line 43, in <module>
0.401     import urllib3
0.401   File "/var/lang/lib/python3.8/site-packages/urllib3/__init__.py", line 41, in <module>
0.401     raise ImportError(
0.401 ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
0.401 
0.401 During handling of the above exception, another exception occurred:
0.401 
0.401 Traceback (most recent call last):
0.401   File "/var/lang/bin/poetry", line 8, in <module>
0.401     sys.exit(main())
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/console/application.py", line 405, in main
0.401     exit_code: int = Application().run()
0.401   File "/var/lang/lib/python3.8/site-packages/cleo/application.py", line 338, in run
0.401     self.render_error(e, io)
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/console/application.py", line 180, in render_error
0.401     self.set_solution_provider_repository(self._get_solution_provider_repository())
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/console/application.py", line 394, in _get_solution_provider_repository
0.401     from poetry.mixology.solutions.providers.python_requirement_solution_provider import (  # noqa: E501
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/mixology/solutions/providers/__init__.py", line 3, in <module>
0.401     from poetry.mixology.solutions.providers.python_requirement_solution_provider import (
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/mixology/solutions/providers/python_requirement_solution_provider.py", line 9, in <module>
0.401     from poetry.puzzle.exceptions import SolverProblemError
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/puzzle/__init__.py", line 3, in <module>
0.401     from poetry.puzzle.solver import Solver
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/puzzle/solver.py", line 16, in <module>
0.401     from poetry.puzzle.provider import Indicator
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/puzzle/provider.py", line 27, in <module>
0.401     from poetry.packages.direct_origin import DirectOrigin
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/packages/direct_origin.py", line 10, in <module>
0.401     from poetry.inspection.info import PackageInfo
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/inspection/info.py", line 26, in <module>
0.401     from poetry.utils.env import EnvCommandError
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/utils/env/__init__.py", line 9, in <module>
0.401     from poetry.utils.env.base_env import Env
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/utils/env/base_env.py", line 18, in <module>
0.401     from poetry.utils.env.site_packages import SitePackages
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/utils/env/site_packages.py", line 11, in <module>
0.401     from poetry.utils.helpers import is_dir_writable
0.401   File "/var/lang/lib/python3.8/site-packages/poetry/utils/helpers.py", line 17, in <module>
0.401     from requests.utils import atomic_open
0.401   File "/var/lang/lib/python3.8/site-packages/requests/__init__.py", line 43, in <module>
0.401     import urllib3
0.401   File "/var/lang/lib/python3.8/site-packages/urllib3/__init__.py", line 41, in <module>
0.401     raise ImportError(
0.401 ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
------
Dockerfile.dependencies:23
--------------------
  21 |     #       that's not the same as the Lambda Python version (ie. Python3.8)
  22 |     RUN if [ -f 'Pipfile' ]; then pipenv requirements > requirements.txt; else echo "Pipfile not found"; fi
  23 | >>> RUN if [ -f 'poetry.lock' ]; then poetry export --with-credentials --format requirements.txt --output requirements.txt; else echo "poetry.lock not found"; fi
  24 |     RUN if [ -f 'requirements.txt' ]; then pip install -r requirements.txt -t .; else echo "requirements.txt not found"; fi
  25 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c if [ -f 'poetry.lock' ]; then poetry export --with-credentials --format requirements.txt --output requirements.txt; else echo \"poetry.lock not found\"; fi" did not complete successfully: exit code: 1
Error: docker exited with status 1
--> Command: docker build -t cdk-47557d116c53c4a44e861e6805cb77da2daf4f3f89fd72aaeb644d16811dc039 -f "/tmp/python-bundling-s2OO2q/Dockerfile.dependencies" --build-arg "IMAGE=public.ecr.aws/sam/build-python3.8" "/tmp/python-bundling-s2OO2q"

Trace: Error: docker exited with status 1
--> Command: docker build -t cdk-47557d116c53c4a44e861e6805cb77da2daf4f3f89fd72aaeb644d16811dc039 -f "/tmp/python-bundling-s2OO2q/Dockerfile.dependencies" --build-arg "IMAGE=public.ecr.aws/sam/build-python3.8" "/tmp/python-bundling-s2OO2q"
    at dockerExec (/home/george/projs/arqgen/repos/scala-datacenters/node_modules/aws-cdk-lib/core/lib/private/asset-staging.js:2:237)
    at Function.fromBuild (/home/george/projs/arqgen/repos/scala-datacenters/node_modules/aws-cdk-lib/core/lib/bundling.js:1:4085)
    at bundle (file:///home/george/projs/arqgen/repos/scala-datacenters/node_modules/sst/runtime/handlers/pythonBundling.js:36:31)
    at Object.build (file:///home/george/projs/arqgen/repos/scala-datacenters/node_modules/sst/runtime/handlers/python.js:94:13)
    at async task (file:///home/george/projs/arqgen/repos/scala-datacenters/node_modules/sst/runtime/handlers.js:39:31)
    at async Object.build (file:///home/george/projs/arqgen/repos/scala-datacenters/node_modules/sst/runtime/handlers.js:90:23)
    at async file:///home/george/projs/arqgen/repos/scala-datacenters/node_modules/sst/constructs/Function.js:200:32
    at process.<anonymous> (file:///home/george/projs/arqgen/repos/scala-datacenters/node_modules/sst/cli/sst.js:56:17)
    at process.emit (node:events:525:35)
    at process.emit (node:domain:489:12)
    at process._fatalException (node:internal/process/execution:149:25)
    at processPromiseRejections (node:internal/process/promises:279:13)
    at processTicksAndRejections (node:internal/process/task_queues:97:32)

```