### PR TITLE
Add dev.command option to SsrSite

### DIFF
--- a/packages/sst/src/cli/commands/dev.tsx
+++ b/packages/sst/src/cli/commands/dev.tsx
@@ -307,7 +307,7 @@ export const dev = (program: Program) =>
                         ? ""
                         : `cd ${props.path} && `;
                     const devCommand =
-                      props.devCommand || `${cdCmd}npm run dev`;
+                      props.dev?.command || `${cdCmd}npm run dev`;
                     Colors.line(
                       Colors.primary(`➜ `),
                       Colors.bold(`Start ${framework}:`),

--- a/packages/sst/src/cli/commands/dev.tsx
+++ b/packages/sst/src/cli/commands/dev.tsx
@@ -306,10 +306,12 @@ export const dev = (program: Program) =>
                       path.resolve(props.path) === process.cwd()
                         ? ""
                         : `cd ${props.path} && `;
+                    const devCommand =
+                      props.devCommand || `${cdCmd}npm run dev`;
                     Colors.line(
                       Colors.primary(`➜ `),
                       Colors.bold(`Start ${framework}:`),
-                      `${cdCmd}npm run dev`
+                      devCommand
                     );
                     Colors.gap();
                   }

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -121,10 +121,6 @@ export interface SsrSiteProps {
    */
   path?: string;
   /**
-   * The command for running the development server.
-   */
-  devCommand?: string;
-  /**
    * The command for building the website
    * @default `npm run build`
    * @example
@@ -239,6 +235,16 @@ export interface SsrSiteProps {
      * ```
      */
     url?: string;
+    /**
+     * The command for running the development server.
+     * @example
+     * ```js
+     * dev: {
+     *   command: "yarn run dev"
+     * }
+     * ```
+     */
+    command?: string;
   };
   /**
    * While deploying, SST waits for the CloudFront cache invalidation process to finish. This ensures that the new content will be served once the deploy command finishes. However, this process can sometimes take more than 5 mins. For non-prod environments it might make sense to pass in `false`. That'll skip waiting for the cache to invalidate and speed up the deploy process.

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -121,6 +121,10 @@ export interface SsrSiteProps {
    */
   path?: string;
   /**
+   * The command for running the development server.
+   */
+  devCommand?: string;
+  /**
    * The command for building the website
    * @default `npm run build`
    * @example


### PR DESCRIPTION
Hello, I noticed that the 'Start {framework}' output seems to be hardcoded to an optional cdCmd (based off of the props.path) and then a hardcoded 'npm run dev' string. In my situation the generated 'cd ../ && npm run dev' was not correct. I have the sst folder in a subdirectory for this specific repo, but both the 'npx sst dev' and 'npm run dev' should be executed in the subdirectory, not one in the subdirectory and one in the parent as the generated message suggests to do.

I think this solution of adding an optional devCommand prop solves this specific case, but also would enable users who might not be using 'npm run dev' to run their dev command to customize that.