### PR TITLE
Add concurrency group name to workflow example

### DIFF
--- a/www/docs/going-to-production.md
+++ b/www/docs/going-to-production.md
@@ -116,6 +116,9 @@ To setup OpenID Connect:
      on:
        push
 
+     # concurrency group name ensures concurrent workflow runs wait for any in-progress job to finish
+     concurrency: merge-${{ github.ref }}
+
      # permission can be added at job level or workflow level    
    + permissions:
    +   id-token: write   # This is required for requesting the JWT


### PR DESCRIPTION
You can't deploy if an existing deploy in progress, so multiple merges will cause github action sst deploy workflows to run concurrently which will fail. 
Adding a concurrency group name using the branch ref will ensure that only 1 workflow run is executed at a time for that branch, any new ones will be queued until current one is finished.