### PR TITLE
Updating retrier function runtime from v14 to v18.

### DIFF
--- a/packages/sst/src/constructs/EventBus.ts
+++ b/packages/sst/src/constructs/EventBus.ts
@@ -605,7 +605,7 @@ export class EventBus extends Construct implements SSTConstruct {
     });
     this.retrierFn = new lambda.Function(this, `RetrierFunction`, {
       functionName: app.logicalPrefixedName(this.node.id + "Retrier"),
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       timeout: Duration.seconds(30),
       handler: "index.handler",
       code: lambda.Code.fromAsset(


### PR DESCRIPTION
Updating retrier function runtime from v14 to v18.

I received the following email from AWS regarding the end-of-support for v14.

> We are contacting you as we have identified that your AWS Account currently has one or more Lambda functions using the Node.js 14 runtime.

> We are ending support for Node.js 14 in AWS Lambda. This follows Node.js 14 End-Of-Life (EOL) reached on April 30, 2023 [1].

> As described in the Lambda runtime support policy [2], end of support for language runtimes in Lambda happens in two stages. Starting November 27, 2023, Lambda will no longer apply security patches and other updates to the Node.js 14 runtime used by Lambda functions, and functions using Node.js 14 will no longer be eligible for technical support. In addition, you will no longer be able to create new Lambda functions using the Node.js 14 runtime. Starting January 25, 2024, you will no longer be able to update existing functions using the Node.js 14 runtime.

> We recommend that you upgrade your existing Node.js 14 functions to Node.js 18 before November 27, 2023.

> End of support does not impact function execution. Your functions will continue to run. However, they will be running on an unsupported runtime which is no longer maintained or patched by the AWS Lambda team.