### PR TITLE
Add healthcheck props to Service construct

### DIFF
--- a/.changeset/smart-oranges-change.md
+++ b/.changeset/smart-oranges-change.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Container: support customizing ALB target group (ie. health check)

--- a/packages/sst/src/constructs/Service.ts
+++ b/packages/sst/src/constructs/Service.ts
@@ -175,7 +175,6 @@ const supportedMemories = {
 };
 
 export interface ServiceDomainProps extends DistributionDomainProps {}
-export interface ServiceHealthCheck extends HealthCheck {}
 export interface ServiceProps {
   /**
    * Path to the directory where the app is located.
@@ -293,22 +292,16 @@ export interface ServiceProps {
   };
   /**
    * Healthcheck for your service. This is used by the load balancer to determine if the container is healthy.
-   * @default
+   *
+   * @example
    * ```js
    * {
-   *   enabled: true,
-   *   healthyHttpCodes: '200',
-   *   healthyThresholdCount: 5,
-   *   interval: CdkDuration.seconds(10),
+   *   healthyHttpCodes: '200-299',
    *   path: "/",
-   *   port: "traffic-port",
-   *   protocol: Protocol.HTTP,
-   *   timeout: CdkDuration.seconds(6),
-   *   unhealthyThresholdCount: 2,
    * }
    * ```
    */
-  healthCheck?: ServiceHealthCheck;
+  healthCheck?: HealthCheck;
   /**
    * Bind resources for the function
    *

--- a/packages/sst/src/constructs/Service.ts
+++ b/packages/sst/src/constructs/Service.ts
@@ -175,6 +175,7 @@ const supportedMemories = {
 };
 
 export interface ServiceDomainProps extends DistributionDomainProps {}
+export interface ServiceHealthCheck extends HealthCheck {}
 export interface ServiceProps {
   /**
    * Path to the directory where the app is located.
@@ -307,7 +308,7 @@ export interface ServiceProps {
    * }
    * ```
    */
-  healthCheck?: HealthCheck;
+  healthCheck?: ServiceHealthCheck;
   /**
    * Bind resources for the function
    *

--- a/packages/sst/test/constructs/Service.test.ts
+++ b/packages/sst/test/constructs/Service.test.ts
@@ -399,6 +399,20 @@ test("scaling.requestsPerContainer defined", async () => {
   });
 });
 
+test("healthCheck", async () => {
+  const { service, stack } = await createService({
+    healthCheck: {
+      healthyHttpCodes: "200, 302",
+      path: "/health",
+    },
+  });
+  hasResource(stack, "AWS::ElasticLoadBalancingV2::TargetGroup", {
+    Matcher: {
+      HttpCode: "200, 302",
+    },
+    HealthCheckPath: "/health",
+  });
+});
 test("bind", async () => {
   const { stack } = await createService((stack) => {
     const topic = new Topic(stack, "Topic");

--- a/www/docs/constructs/Service.about.md
+++ b/www/docs/constructs/Service.about.md
@@ -257,6 +257,24 @@ new Service(stack, "MyService", {
 });
 ```
 
+### Configuring ALB health check
+
+```js
+import { Duration } from "aws-cdk-lib/core";
+
+new Service(stack, "MyService", {
+  path: "./service",
+  cdk: {
+    applicationLoadBalancerTargetGroup: {
+      healthCheck: {
+        healthyHttpCodes: "200, 302",
+        path: "/health",
+      },
+    },
+  },
+});
+```
+
 ### Configuring container health check
 
 ```js

--- a/www/generate.mjs
+++ b/www/generate.mjs
@@ -31,7 +31,7 @@ const CDK_DOCS_MAP = {
   ISecret: "aws_secretsmanager",
   IApplicationListener: "aws_elasticloadbalancingv2",
   INetworkListener: "aws_elasticloadbalancingv2",
-  HealthCheck: "aws_elasticloadbalancingv2",
+  ApplicationTargetGroupProps: "aws_elasticloadbalancingv2",
   Certificate: "aws_certificatemanager",
   ICertificate: "aws_certificatemanager",
   DnsValidatedCertificate: "aws_certificatemanager",

--- a/www/generate.mjs
+++ b/www/generate.mjs
@@ -31,6 +31,7 @@ const CDK_DOCS_MAP = {
   ISecret: "aws_secretsmanager",
   IApplicationListener: "aws_elasticloadbalancingv2",
   INetworkListener: "aws_elasticloadbalancingv2",
+  HealthCheck: "aws_elasticloadbalancingv2",
   Certificate: "aws_certificatemanager",
   ICertificate: "aws_certificatemanager",
   DnsValidatedCertificate: "aws_certificatemanager",


### PR DESCRIPTION
Added configurable health check to the target group created within the Service construct. Further to the discussion on [Discord](https://discord.com/channels/983865673656705025/991751731824308344/1146893038027817000)

The default health check created assumes that the root path of the service task returns an HTTP 200 response. When deploying 3rd party images or applying security to the service this may not be the case. If the default health check fails the deployment of the Service times out as the deployment internally for CF/Fargate does not complete. This change retains all the default configuration but enables any of the [HealthCheck](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_elasticloadbalancingv2.HealthCheck.html) props to be set. 

I considered placing this configuration inside the existing `cdk` props but concluded that this is actually a config that refers to the Service you are defining.
