### PR TITLE
SsrSite: Upgrade s3 handler python versions

### DIFF
--- a/.changeset/forty-ties-retire.md
+++ b/.changeset/forty-ties-retire.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+SsrSite: Upgrade s3 handler python versions

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -795,7 +795,7 @@ export abstract class SsrSite extends Construct implements SSTConstruct {
         path.join(__dirname, "../support/base-site-custom-resource")
       ),
       layers: [cliLayer],
-      runtime: Runtime.PYTHON_3_7,
+      runtime: Runtime.PYTHON_3_11,
       handler: "s3-upload.handler",
       timeout: CdkDuration.minutes(15),
       memorySize: 1024,
@@ -809,7 +809,7 @@ export abstract class SsrSite extends Construct implements SSTConstruct {
         path.join(__dirname, "../support/base-site-custom-resource")
       ),
       layers: [cliLayer],
-      runtime: Runtime.PYTHON_3_7,
+      runtime: Runtime.PYTHON_3_11,
       handler: "s3-handler.handler",
       timeout: CdkDuration.minutes(15),
       memorySize: 1024,

--- a/packages/sst/support/base-site-custom-resource/s3-upload.py
+++ b/packages/sst/support/base-site-custom-resource/s3-upload.py
@@ -1,12 +1,10 @@
 import subprocess
 import os
 import tempfile
-import json
 import glob
 import logging
 import shutil
 import boto3
-import asyncio
 from uuid import uuid4
 from zipfile import ZipFile
 


### PR DESCRIPTION
https://github.com/sst/sst/pull/3266 upgrades the remaining nodejs 14 resource functions to nodejs 16 in response to the deprecation warning from AWS. This PR does the same thing but for the Python3.7 deprecation warning

```
We are contacting you as we have identified that your AWS Account currently has one or more Lambda functions using the Python 3.7 runtime.

We are ending support for Python 3.7 in AWS Lambda. This follows Python 3.7 End-Of-Life (EOL) reached on June 27, 2023 [1].
```

The email suggests upgrading to 3.11 which I've done here -- I believe it should be backwards compatible. Also I removed some unused imports I noticed in `s3-upload.py`