### PR TITLE
StaticSite: Upgrade S3 uploader and handler Pyhon versions 3_7 -> 3_11

### DIFF
--- a/.changeset/silly-geckos-invite.md
+++ b/.changeset/silly-geckos-invite.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+StaticSite: Upgrade S3 uploader and handler Pyhon versions 3_7 -> 3_11

--- a/packages/sst/src/constructs/StaticSite.ts
+++ b/packages/sst/src/constructs/StaticSite.ts
@@ -690,7 +690,7 @@ interface ImportMeta {
         path.join(__dirname, "../support/base-site-custom-resource")
       ),
       layers: [cliLayer],
-      runtime: Runtime.PYTHON_3_7,
+      runtime: Runtime.PYTHON_3_11,
       handler: "s3-upload.handler",
       timeout: Duration.minutes(15),
       memorySize: 1024,
@@ -704,7 +704,7 @@ interface ImportMeta {
         path.join(__dirname, "../support/base-site-custom-resource")
       ),
       layers: [cliLayer],
-      runtime: Runtime.PYTHON_3_7,
+      runtime: Runtime.PYTHON_3_11,
       handler: "s3-handler.handler",
       timeout: Duration.minutes(15),
       memorySize: 1024,


### PR DESCRIPTION
This PR is similar to https://github.com/sst/sst/pull/3266 for SsrSite, except this one upgrade Python versions for [StaticSite](https://github.com/sst/sst/blob/master/packages/sst/src/constructs/StaticSite.ts#L693) construct