### PR TITLE
node/event-bus: Fix incompatible type inference in exported function

### DIFF
--- a/.changeset/clean-badgers-brush.md
+++ b/.changeset/clean-badgers-brush.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+node/event-bus: Fix incompatible type inference in exported function

--- a/packages/sst/src/node/event-bus/index.ts
+++ b/packages/sst/src/node/event-bus/index.ts
@@ -16,6 +16,15 @@ import { ZodAny, ZodObject, ZodRawShape, z } from "zod";
 import { useLoader } from "../util/loader.js";
 import { Config } from "../config/index.js";
 
+/**
+ * PutEventsCommandOutput is used in return type of createEvent, in case the consumer of SST builds
+ * their project with declaration files, this is not portable. In order to allow TS to generate a
+ * declaration file without reference to @aws-sdk/client-eventbridge, we must re-export the type.
+ *
+ * More information here: https://github.com/microsoft/TypeScript/issues/47663#issuecomment-1519138189
+ */
+export { PutEventsCommandOutput };
+
 const client = new EventBridgeClient({});
 
 export function createEventBuilder<


### PR DESCRIPTION
Currently `createEvent` (returned by `createEventBuilder`) has an inferred return type. The return type refers to a type ` PutEventsCommandOutput ` imported from `@aws-sdk/client-eventbridge`. When a consumer of SST uses `sst/node/event-bus` and has TS config option to emit declaration files, they get a declaration file like this:

Input file:
```ts
import { createEventBuilder } from 'sst/node/event-bus';

export const event = createEventBuilder({
  bus: 'bus',
});
```

Declaration file:
```ts
export declare const event: <Type extends string, Shape extends import("zod").ZodRawShape, Properties = import("zod").objectOutputType<Shape, import("zod").ZodAny, "strip">>(type: Type, properties: Shape) => {
    publish: (properties: Properties) => Promise<import("@aws-sdk/client-eventbridge").PutEventsCommandOutput>;
    type: Type;
    shape: {
        metadata: undefined;
        properties: Properties;
        metadataFn: any;
    };
};
```

This will produce an error such as:
```
The inferred type of 'event' cannot be named without a reference to '.pnpm/@aws-sdk+client-eventbridge@3.395.0_@aws-sdk+signature-v4-crt@3.391.0/node_modules/@aws-sdk/client-eventbridge'. This is likely not portable. A type annotation is necessary.ts(2742)
```

In order to make the inferred type portable, we can re-export the type, after which the declaration file will look like this:
```ts
export declare const event: <Type extends string, Shape extends import("zod").ZodRawShape, Properties = import("zod").objectOutputType<Shape, import("zod").ZodAny, "strip">>(type: Type, properties: Shape) => {
    publish: (properties: Properties) => Promise<import("sst/node/event-bus").PutEventsCommandOutput>;
    type: Type;
    shape: {
        metadata: undefined;
        properties: Properties;
        metadataFn: any;
    };
};
```

After which everything is portable.

PS. This problem can easily be re-produced in the todo example app by enabling `"declaration": true` in the tsconfig.json.
PPS. More info about the issue in this TS issue & comment: https://github.com/microsoft/TypeScript/issues/47663#issuecomment-1519138189