### PR TITLE
Env vars in .env files should not override existing env vars

### DIFF
--- a/packages/sst/src/cli/sst.ts
+++ b/packages/sst/src/cli/sst.ts
@@ -9,11 +9,11 @@ import { Logger } from "../logger.js";
 
 import dotenv from "dotenv";
 dotenv.config({
-  override: true,
+  override: false,
 });
 dotenv.config({
   path: ".env.local",
-  override: true,
+  override: false,
 });
 
 import { bootstrap } from "./commands/bootstrap.js";

--- a/packages/sst/src/project.ts
+++ b/packages/sst/src/project.ts
@@ -203,10 +203,10 @@ export async function initProject(globals: GlobalOptions) {
 
   // Load .env files
   [
-    path.join(project.paths.root, `.env`),
-    path.join(project.paths.root, `.env.local`),
-    path.join(project.paths.root, `.env.${project.config.stage}`),
     path.join(project.paths.root, `.env.${project.config.stage}.local`),
+    path.join(project.paths.root, `.env.${project.config.stage}`),
+    path.join(project.paths.root, `.env.local`),
+    path.join(project.paths.root, `.env`),
   ].forEach((path) => dotenv.config({ path, override: false }));
 
   Logger.debug("Config loaded", project);

--- a/packages/sst/src/project.ts
+++ b/packages/sst/src/project.ts
@@ -207,7 +207,7 @@ export async function initProject(globals: GlobalOptions) {
     path.join(project.paths.root, `.env.local`),
     path.join(project.paths.root, `.env.${project.config.stage}`),
     path.join(project.paths.root, `.env.${project.config.stage}.local`),
-  ].forEach((path) => dotenv.config({ path, override: true }));
+  ].forEach((path) => dotenv.config({ path, override: false }));
 
   Logger.debug("Config loaded", project);
 }


### PR DESCRIPTION
Fixes #2523 

Notes:
- An existing PR (https://github.com/sst/sst/pull/2934) for the same issue was closed before review/merge
- Thought it would be better to keep the override behavior explicit in the code rather than rely on dotenv's defaults. Let me know if you guys really want the `override` attr gone