### PR TITLE
Fix RemixSite enforcing ESM

### DIFF
--- a/.changeset/six-tomatoes-rest.md
+++ b/.changeset/six-tomatoes-rest.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+RemixSite: do not enforce ESM

--- a/packages/sst/src/constructs/RemixSite.ts
+++ b/packages/sst/src/constructs/RemixSite.ts
@@ -15,7 +15,6 @@ type RemixConfig = {
   assetsBuildDirectory: string;
   publicPath: string;
   serverBuildPath: string;
-  serverModuleFormat: string;
   serverPlatform: string;
   server?: string;
 };

--- a/packages/sst/src/constructs/RemixSite.ts
+++ b/packages/sst/src/constructs/RemixSite.ts
@@ -43,7 +43,6 @@ export class RemixSite extends SsrSite {
       assetsBuildDirectory: "public/build",
       publicPath: "/build/",
       serverBuildPath: "build/index.js",
-      serverModuleFormat: "esm",
       serverPlatform: "node",
     };
 


### PR DESCRIPTION
Enforcing a `serverModuleFormat` is no longer needed now that both formats are supported.
Fixes the issue raised at  https://discord.com/channels/983865673656705025/1072426878431940758/1152175369823211573