### PR TITLE
Fix: Update deprecated appsync schema prop

### DIFF
--- a/.changeset/itchy-steaks-beam.md
+++ b/.changeset/itchy-steaks-beam.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+AppSyncApi: Update deprecated appsync schema prop

--- a/packages/sst/src/constructs/AppSyncApi.ts
+++ b/packages/sst/src/constructs/AppSyncApi.ts
@@ -43,6 +43,7 @@ import {
   Resolver,
   ResolverProps,
   SchemaFile,
+  Definition,
 } from "aws-cdk-lib/aws-appsync";
 import { ICertificate } from "aws-cdk-lib/aws-certificatemanager";
 import { IDomain } from "aws-cdk-lib/aws-opensearchservice";
@@ -806,7 +807,7 @@ export class AppSyncApi extends Construct implements SSTConstruct {
       this.cdk.graphqlApi = new GraphqlApi(this, "Api", {
         name: app.logicalPrefixedName(id),
         xrayEnabled: true,
-        schema: mainSchema,
+        definition: Definition.fromSchema(mainSchema),
         domainName: domainData && {
           certificate: domainData.certificate,
           domainName: domainData.domainName,


### PR DESCRIPTION
Resolves the warning

```
[WARNING] aws-cdk-lib.aws_appsync.GraphqlApiProps#schema is deprecated.
  use apiSoure.schema instead
  This API will be removed in the next major release.
```

Note: one of the tests is failing (merging array of schema files), but this is unrelated to this PR and has been failing for a a while. I was unable to fix the error so have left it.