### PR TITLE
Update ExampleStack.ts

### DIFF
--- a/examples/api-auth-jwt-auth0/stacks/ExampleStack.ts
+++ b/examples/api-auth-jwt-auth0/stacks/ExampleStack.ts
@@ -7,8 +7,8 @@ export function ExampleStack({ stack, app }: StackContext) {
       auth0: {
         type: "jwt",
         jwt: {
-          issuer: process.env.AUTH0_DOMAIN!,
-          audience: [process.env.AUTH0_DOMAIN + "api/v2/"],
+          issuer: `https://${process.env.AUTH0_DOMAIN!}`,
+          audience: [`https://${process.env.AUTH0_DOMAIN}` + "api/v2/"],
         },
       },
     },


### PR DESCRIPTION
The use of `VITE_APP_AUTH0_DOMAIN` in the frontend assumes that `https://` is not already a part of the VITE_APP_AUTH0_DOMAIN. But the backend expects it, otherwise aws gives the error ""Invalid issuer: Issuer is not a valid URL for JWT Authorizer"

```
getAccessTokenSilently({
        audience: `https://${import.meta.env.VITE_APP_AUTH0_DOMAIN}/api/v2/`,
        scope: "read:current_user",
      });)
```      
