### PR TITLE
Future Auth: Fix session checking not working for websocket API's

### DIFF
--- a/packages/sst/src/node/future/auth/session.ts
+++ b/packages/sst/src/node/future/auth/session.ts
@@ -20,7 +20,8 @@ const SessionMemo = /* @__PURE__ */ Context.memo(() => {
   // Get the context type and hooks that match that type
   let token = "";
 
-  const header = useHeader("authorization")!;
+  // Websockets don't lowercase headers
+  const header = useHeader("authorization") || useHeader("Authorization");
   if (header) token = header.substring(7);
 
   const ctxType = useContextType();


### PR DESCRIPTION
For some reason AWS does not lowercase header names in Websocket events, so the `useSession` utility does not work.

There's also this PR from a while ago mentioned in a comment in the same file that would fix this issue in a possibly better way https://github.com/sst/sst/pull/2838/.