### PR TITLE
SSRSites/Service: Fix `waitForInvalidation` not being passed down to `Distribution`

### DIFF
--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -302,13 +302,14 @@ export class NextjsSite extends SsrSite {
      *    - x-vercel-cache: MISS
      */
 
-    const { customDomain, cdk } = this.props;
+    const { customDomain, waitForInvalidation, cdk } = this.props;
     const cfDistributionProps = cdk?.distribution || {};
     const serverBehavior = this.buildDefaultBehaviorForRegional();
 
     return new Distribution(this, "CDN", {
       scopeOverride: this,
       customDomain,
+      waitForInvalidation,
       cdk: {
         distribution: {
           // these values can be overwritten by cfDistributionProps
@@ -329,13 +330,14 @@ export class NextjsSite extends SsrSite {
   }
 
   protected createCloudFrontDistributionForEdge() {
-    const { customDomain, cdk } = this.props;
+    const { customDomain, waitForInvalidation, cdk } = this.props;
     const cfDistributionProps = cdk?.distribution || {};
     const serverBehavior = this.buildDefaultBehaviorForEdge();
 
     return new Distribution(this, "CDN", {
       scopeOverride: this,
       customDomain,
+      waitForInvalidation,
       cdk: {
         distribution: {
           // these values can be overwritten by cfDistributionProps

--- a/packages/sst/src/constructs/Service.ts
+++ b/packages/sst/src/constructs/Service.ts
@@ -980,7 +980,7 @@ export class Service extends Construct implements SSTConstruct {
   }
 
   private createDistribution(alb?: ApplicationLoadBalancer) {
-    const { cdk, customDomain } = this.props;
+    const { cdk, customDomain, waitForInvalidation } = this.props;
 
     // Do not create distribution if disabled or if ALB was not created (ie. disabled)
     if (!alb || cdk?.cloudfrontDistribution === false) return;
@@ -999,6 +999,7 @@ export class Service extends Construct implements SSTConstruct {
 
     return new Distribution(this, "CDN", {
       customDomain,
+      waitForInvalidation,
       cdk: {
         distribution: {
           defaultRootObject: "",

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -1019,12 +1019,13 @@ export abstract class SsrSite extends Construct implements SSTConstruct {
   }
 
   protected createCloudFrontDistributionForRegional() {
-    const { customDomain, cdk } = this.props;
+    const { customDomain, waitForInvalidation, cdk } = this.props;
     const cfDistributionProps = cdk?.distribution || {};
 
     return new Distribution(this, "CDN", {
       scopeOverride: this,
       customDomain,
+      waitForInvalidation,
       cdk: {
         distribution: {
           // these values can be overwritten by cfDistributionProps
@@ -1042,12 +1043,13 @@ export abstract class SsrSite extends Construct implements SSTConstruct {
   }
 
   protected createCloudFrontDistributionForEdge() {
-    const { customDomain, cdk } = this.props;
+    const { customDomain, waitForInvalidation, cdk } = this.props;
     const cfDistributionProps = cdk?.distribution || {};
 
     return new Distribution(this, "CDN", {
       scopeOverride: this,
       customDomain,
+      waitForInvalidation,
       cdk: {
         distribution: {
           // these values can be overwritten by cfDistributionProps

--- a/packages/sst/src/constructs/StaticSite.ts
+++ b/packages/sst/src/constructs/StaticSite.ts
@@ -756,12 +756,13 @@ interface ImportMeta {
   /////////////////////
 
   private createCfDistribution(): Distribution {
-    const { errorPage, customDomain, cdk } = this.props;
+    const { errorPage, customDomain, waitForInvalidation, cdk } = this.props;
     const indexPage = this.props.indexPage || "index.html";
 
     return new Distribution(this, "CDN", {
       scopeOverride: this,
       customDomain,
+      waitForInvalidation,
       cdk: {
         distribution:
           cdk?.distribution && isCDKConstruct(cdk.distribution)


### PR DESCRIPTION
This prop seems to have been omitted by mistake when the new `Distribution` construct was created. I added the prop in all the places that create a new Distribution.