### PR TITLE
feat: Improved Astro SSR Support

### DIFF
--- a/packages/astro-sst/package.json
+++ b/packages/astro-sst/package.json
@@ -39,12 +39,12 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@astrojs/webapi": "^2.1.0",
+    "@astrojs/webapi": "^3.0.0",
     "set-cookie-parser": "^2.6.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.112",
     "@types/set-cookie-parser": "^2.4.3",
-    "astro": "^2.1.3"
+    "astro": "^3.1.4"
   }
 }

--- a/packages/astro-sst/src/edge/adapter.ts
+++ b/packages/astro-sst/src/edge/adapter.ts
@@ -1,4 +1,5 @@
 import type { AstroAdapter, AstroIntegration } from "astro";
+import { BuildMeta } from "../lib/build-meta";
 
 const PACKAGE_NAME = "astro-sst/edge";
 
@@ -14,8 +15,13 @@ export default function createIntegration(): AstroIntegration {
   return {
     name: PACKAGE_NAME,
     hooks: {
-      "astro:config:done": ({ setAdapter }) => {
+      "astro:config:done": ({ config, setAdapter }) => {
+        BuildMeta.setAstroConfig(config);
         setAdapter(getAdapter());
+      },
+      "astro:build:done": async (buildResults) => {
+        BuildMeta.setBuildResults(buildResults);
+        await BuildMeta.exportBuildMeta();
       },
     },
   };

--- a/packages/astro-sst/src/lambda/adapter.ts
+++ b/packages/astro-sst/src/lambda/adapter.ts
@@ -1,4 +1,5 @@
 import type { AstroAdapter, AstroIntegration } from "astro";
+import { BuildMeta } from "../lib/build-meta";
 
 const PACKAGE_NAME = "astro-sst/lambda";
 
@@ -14,8 +15,13 @@ export default function createIntegration(): AstroIntegration {
   return {
     name: PACKAGE_NAME,
     hooks: {
-      "astro:config:done": ({ setAdapter }) => {
+      "astro:config:done": ({ config, setAdapter }) => {
+        BuildMeta.setAstroConfig(config);
         setAdapter(getAdapter());
+      },
+      "astro:build:done": async (buildResults) => {
+        BuildMeta.setBuildResults(buildResults);
+        await BuildMeta.exportBuildMeta();
       },
     },
   };

--- a/packages/astro-sst/src/lib/build-meta.ts
+++ b/packages/astro-sst/src/lib/build-meta.ts
@@ -1,0 +1,78 @@
+import type {
+  AstroConfig,
+  RouteData,
+  RouteType,
+  ValidRedirectStatus,
+} from "astro";
+import { join, relative } from "path";
+import { writeFile } from "fs/promises";
+import { fileURLToPath } from "url";
+
+const BUILD_EXPORT_NAME = "sst.buildMeta.json";
+
+type BuildResults = {
+  pages: {
+    pathname: string;
+  }[];
+  dir: URL;
+  routes: RouteData[];
+};
+
+type SerializableRoute = {
+  route: string;
+  type: RouteType;
+  pattern: string;
+  prerender: boolean;
+  redirectPath?: string;
+  redirectStatus?: ValidRedirectStatus;
+};
+
+export class BuildMeta {
+  protected static astroConfig: AstroConfig;
+  protected static buildResults: BuildResults;
+
+  public static setAstroConfig(config: AstroConfig) {
+    this.astroConfig = config;
+  }
+
+  public static setBuildResults(buildResults: BuildResults) {
+    this.buildResults = buildResults;
+  }
+
+  private static serializableRoute(route: RouteData): SerializableRoute {
+    return {
+      route: route.route,
+      type: route.type,
+      pattern: route.pattern.toString(),
+      prerender: route.prerender,
+      redirectPath:
+        typeof route.redirect === "string"
+          ? route.redirect
+          : route.redirect?.destination,
+      redirectStatus:
+        typeof route.redirect === "object" ? route.redirect.status : undefined,
+    };
+  }
+
+  public static async exportBuildMeta(buildExportName = BUILD_EXPORT_NAME) {
+    const rootDir = fileURLToPath(this.astroConfig.root);
+
+    const outputPath = join(
+      relative(rootDir, fileURLToPath(this.astroConfig.outDir)),
+      buildExportName
+    );
+
+    const buildMeta = {
+      astroSite: {
+        outputMode: this.astroConfig.output,
+        pageResolution: this.astroConfig.build.format,
+        trailingSlash: this.astroConfig.trailingSlash,
+        routes: this.buildResults.routes.map((route) =>
+          this.serializableRoute(route)
+        ),
+      },
+    };
+
+    await writeFile(outputPath, JSON.stringify(buildMeta));
+  }
+}

--- a/packages/sst/src/config.ts
+++ b/packages/sst/src/config.ts
@@ -272,7 +272,6 @@ async function* scanParameters(prefix: string) {
         NextToken: token,
       })
     );
-    console.log("results", results.Parameters?.length);
     yield* results.Parameters || [];
 
     if (!results.NextToken) break;

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -738,7 +738,8 @@ export abstract class SsrSite extends Construct implements SSTConstruct {
         return {
           origin,
           viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-          allowedMethods: behavior.allowedMethods ?? AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+          allowedMethods:
+            behavior.allowedMethods ?? AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
           cachedMethods: CachedMethods.CACHE_GET_HEAD_OPTIONS,
           compress: true,
           cachePolicy: CachePolicy.CACHING_OPTIMIZED,

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -7,7 +7,6 @@ import spawn from "cross-spawn";
 import { execSync } from "child_process";
 
 import { Construct } from "constructs";
-import { Lazy } from "aws-cdk-lib";
 import {
   Fn,
   Token,
@@ -37,7 +36,6 @@ import {
   FunctionUrlAuthType,
   FunctionProps as CdkFunctionProps,
   InvokeMode,
-  Architecture,
 } from "aws-cdk-lib/aws-lambda";
 import { Asset } from "aws-cdk-lib/aws-s3-assets";
 import {
@@ -58,8 +56,6 @@ import {
   Function as CfFunction,
   FunctionCode as CfFunctionCode,
   FunctionEventType as CfFunctionEventType,
-  IDistribution,
-  IOrigin,
 } from "aws-cdk-lib/aws-cloudfront";
 import { AwsCliLayer } from "aws-cdk-lib/lambda-layer-awscli";
 import { S3Origin, HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
@@ -92,7 +88,6 @@ import {
 import { useProject } from "../project.js";
 import { VisibleError } from "../error.js";
 import { RetentionDays } from "aws-cdk-lib/aws-logs";
-import { Behavior } from "@aws-sdk/client-iot";
 
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -382,7 +382,7 @@ export interface SsrSiteProps {
   fileOptions?: SsrSiteFileOptions[];
 }
 
-type SsrSiteNormalizedProps = SsrSiteProps & {
+export type SsrSiteNormalizedProps = SsrSiteProps & {
   path: Exclude<SsrSiteProps["path"], undefined>;
   runtime: Exclude<SsrSiteProps["runtime"], undefined>;
   timeout: Exclude<SsrSiteProps["timeout"], undefined>;


### PR DESCRIPTION
_Continuation of the work started in #3176 and leveraging the improvements made by @fwang in #3340._

PR improves the implementation of Astro SSR for regional deployments (CloudFront + S3 & Lambda). The Astro plugin now produces a meta file at build time containing the routing information for the site which is used to produce a deployment specific CF Function. The deployment strategy also shifts from behavior mapping of static files to a blanket S3 attempt on most routes with a fall-through to the Lambda function on a miss.

**Advantages of this implementation:**
- CF Function performs document postfixing (`/index.html`) for directory routing, so `coolsite.com/about/index.html` now becomes `coolsite.com/about`.
- CF Function performs mapped redirects at the CDN level without activating Lambda function.
- Allows static and dynamic content in the same directory.
- Removes limitation of 25 static files/directories in the root of the site.

**Disadvantages of this implementation:**
- Attempts S3 before Lambda fall-through so theoretical overhead added to all SSR requests.
- All routes only support `GET`, `HEAD`, `OPTIONS` methods by default.

Both of the limitations noted as disadvantages are mitigated through use of the `ssrExclusiveRoutes` property on the SST Config. The route patterns from this property are mapped to behaviors which bypass the S3 static file check and support all request methods (`GET`, `POST`, `PUT`, `DELETE`, etc.). These are also route patterns, so API routes only require declaration of the root directory (`/api/*`).

Example configuration for a simple site:
```ts
app.stack(function Site({ stack }) {
  const site = new AstroSite(stack, `astro-site`, {
    ssrExclusiveRoutes: [
      'feedback', // Feedback page which requires POST method
      'login',    // Login page which requires POST method
      'user/*',   // Directory of user routes which are all SSR
      'api/*'     // Directory of API endpoints which require all methods
    ]
  })
})
```

Resolves #3139