### PR TITLE
Add option for using prebuilt Rust binary

### DIFF
--- a/.changeset/sweet-buttons-cry.md
+++ b/.changeset/sweet-buttons-cry.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Add option for using prebuilt Rust binary

--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -129,6 +129,11 @@ export interface FunctionProps
   go?: GoProps;
 
   /**
+   * Used to configure rust function properties
+   */
+  rust?: RustProps;
+
+  /**
    * Used to configure nodejs function properties
    */
   nodejs?: NodeJSProps;
@@ -582,6 +587,23 @@ export interface GoProps {
    * ```
    */
   cgoEnabled?: boolean;
+}
+
+/**
+ * Used to configure Rust bundling options
+ */
+export interface RustProps {
+  /**
+   * The path to a precompiled Rust binary to use instead of letting SST compile the Rust code for you.
+   *
+   * @example
+   * ```js
+   * rust: {
+   *   prebuild: "./target/lambda/main/bootstrap",
+   * }
+   * ```
+   */
+  prebuilt?: string;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -579,295 +579,6 @@ importers:
         version: 0.33.0
     publishDirectory: dist
 
-  packages/sst/dist:
-    dependencies:
-      '@aws-cdk/aws-apigatewayv2-alpha':
-        specifier: ^2.95.1-alpha.0
-        version: 2.95.1-alpha.0(aws-cdk-lib@2.95.1)(constructs@10.2.69)
-      '@aws-cdk/aws-apigatewayv2-authorizers-alpha':
-        specifier: ^2.95.1-alpha.0
-        version: 2.95.1-alpha.0(@aws-cdk/aws-apigatewayv2-alpha@2.95.1-alpha.0)(aws-cdk-lib@2.95.1)(constructs@10.2.69)
-      '@aws-cdk/aws-apigatewayv2-integrations-alpha':
-        specifier: ^2.95.1-alpha.0
-        version: 2.95.1-alpha.0(@aws-cdk/aws-apigatewayv2-alpha@2.95.1-alpha.0)(aws-cdk-lib@2.95.1)(constructs@10.2.69)
-      '@aws-cdk/cloud-assembly-schema':
-        specifier: 2.95.1
-        version: 2.95.1
-      '@aws-cdk/cloudformation-diff':
-        specifier: 2.95.1
-        version: 2.95.1
-      '@aws-cdk/cx-api':
-        specifier: 2.95.1
-        version: 2.95.1(@aws-cdk/cloud-assembly-schema@2.95.1)
-      '@aws-crypto/sha256-js':
-        specifier: ^5.0.0
-        version: 5.0.0
-      '@aws-sdk/client-cloudformation':
-        specifier: ^3.405.0
-        version: 3.405.0
-      '@aws-sdk/client-ecs':
-        specifier: ^3.405.0
-        version: 3.405.0
-      '@aws-sdk/client-eventbridge':
-        specifier: ^3.405.0
-        version: 3.405.0(@aws-sdk/signature-v4-crt@3.398.0)
-      '@aws-sdk/client-iam':
-        specifier: ^3.405.0
-        version: 3.405.0
-      '@aws-sdk/client-iot':
-        specifier: ^3.405.0
-        version: 3.405.0
-      '@aws-sdk/client-iot-data-plane':
-        specifier: ^3.405.0
-        version: 3.405.0
-      '@aws-sdk/client-lambda':
-        specifier: ^3.405.0
-        version: 3.405.0
-      '@aws-sdk/client-rds-data':
-        specifier: ^3.405.0
-        version: 3.405.0
-      '@aws-sdk/client-s3':
-        specifier: ^3.405.0
-        version: 3.405.0(@aws-sdk/signature-v4-crt@3.398.0)
-      '@aws-sdk/client-ssm':
-        specifier: ^3.405.0
-        version: 3.405.0
-      '@aws-sdk/client-sts':
-        specifier: ^3.405.0
-        version: 3.405.0
-      '@aws-sdk/config-resolver':
-        specifier: ^3.374.0
-        version: 3.374.0
-      '@aws-sdk/credential-providers':
-        specifier: ^3.405.0
-        version: 3.405.0
-      '@aws-sdk/middleware-retry':
-        specifier: ^3.374.0
-        version: 3.374.0
-      '@aws-sdk/middleware-signing':
-        specifier: ^3.398.0
-        version: 3.398.0
-      '@aws-sdk/signature-v4-crt':
-        specifier: ^3.398.0
-        version: 3.398.0
-      '@aws-sdk/smithy-client':
-        specifier: ^3.374.0
-        version: 3.374.0
-      '@babel/core':
-        specifier: ^7.0.0-0
-        version: 7.22.11
-      '@babel/generator':
-        specifier: ^7.20.5
-        version: 7.22.10
-      '@babel/plugin-syntax-typescript':
-        specifier: ^7.21.4
-        version: 7.21.4(@babel/core@7.22.11)
-      '@smithy/signature-v4':
-        specifier: ^2.0.4
-        version: 2.0.5
-      '@trpc/server':
-        specifier: 9.16.0
-        version: 9.16.0
-      adm-zip:
-        specifier: ^0.5.10
-        version: 0.5.10
-      aws-cdk-lib:
-        specifier: 2.95.1
-        version: 2.95.1(constructs@10.2.69)
-      aws-iot-device-sdk:
-        specifier: ^2.2.12
-        version: 2.2.12
-      aws-sdk:
-        specifier: ^2.1326.0
-        version: 2.1456.0
-      builtin-modules:
-        specifier: 3.2.0
-        version: 3.2.0
-      cdk-assets:
-        specifier: 2.95.1
-        version: 2.95.1
-      chalk:
-        specifier: ^5.2.0
-        version: 5.2.0
-      chokidar:
-        specifier: ^3.5.3
-        version: 3.5.3
-      ci-info:
-        specifier: ^3.7.0
-        version: 3.8.0
-      colorette:
-        specifier: ^2.0.19
-        version: 2.0.19
-      conf:
-        specifier: ^10.2.0
-        version: 10.2.0
-      constructs:
-        specifier: 10.2.69
-        version: 10.2.69
-      cross-spawn:
-        specifier: ^7.0.3
-        version: 7.0.3
-      dendriform-immer-patch-optimiser:
-        specifier: ^2.1.0
-        version: 2.1.3(immer@9.0.16)
-      dotenv:
-        specifier: ^16.0.3
-        version: 16.0.3
-      esbuild:
-        specifier: 0.18.13
-        version: 0.18.13
-      express:
-        specifier: ^4.18.2
-        version: 4.18.2
-      fast-jwt:
-        specifier: ^3.1.1
-        version: 3.1.1
-      get-port:
-        specifier: ^6.1.2
-        version: 6.1.2
-      glob:
-        specifier: ^8.0.3
-        version: 8.0.3
-      graphql:
-        specifier: '*'
-        version: 16.6.0
-      graphql-yoga:
-        specifier: ^3.9.0
-        version: 3.9.1(graphql@16.6.0)
-      immer:
-        specifier: '9'
-        version: 9.0.16
-      ink:
-        specifier: ^4.0.0
-        version: 4.0.0(@types/react@17.0.52)(react@18.2.0)
-      ink-spinner:
-        specifier: ^5.0.0
-        version: 5.0.0(ink@4.0.0)(react@18.2.0)
-      kysely:
-        specifier: ^0.25.0
-        version: 0.25.0
-      kysely-codegen:
-        specifier: ^0.10.1
-        version: 0.10.1(kysely@0.25.0)
-      kysely-data-api:
-        specifier: ^0.2.1
-        version: 0.2.1(@aws-sdk/client-rds-data@3.405.0)(kysely@0.25.0)
-      minimatch:
-        specifier: ^6.1.6
-        version: 6.1.6
-      openid-client:
-        specifier: ^5.1.8
-        version: 5.3.0
-      ora:
-        specifier: ^6.1.2
-        version: 6.1.2
-      react:
-        specifier: 18.2.0
-        version: 18.2.0
-      remeda:
-        specifier: ^1.3.0
-        version: 1.3.0
-      sst-aws-cdk:
-        specifier: 2.91.0
-        version: 2.91.0
-      tree-kill:
-        specifier: ^1.2.2
-        version: 1.2.2
-      undici:
-        specifier: ^5.12.0
-        version: 5.22.0
-      uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
-      ws:
-        specifier: ^8.11.0
-        version: 8.13.0
-      yargs:
-        specifier: ^17.6.2
-        version: 17.7.1
-      zod:
-        specifier: ^3.21.4
-        version: 3.21.4
-    devDependencies:
-      '@aws-sdk/client-api-gateway':
-        specifier: ^3.208.0
-        version: 3.208.0
-      '@aws-sdk/client-cloudfront':
-        specifier: ^3.279.0
-        version: 3.279.0
-      '@aws-sdk/client-codebuild':
-        specifier: ^3.279.0
-        version: 3.279.0
-      '@aws-sdk/client-sqs':
-        specifier: ^3.341.0
-        version: 3.341.0
-      '@aws-sdk/types':
-        specifier: ^3.272.0
-        version: 3.398.0
-      '@graphql-tools/merge':
-        specifier: ^8.3.16
-        version: 8.4.1(graphql@16.6.0)
-      '@sls-next/lambda-at-edge':
-        specifier: ^3.7.0
-        version: 3.7.0(@aws-sdk/signature-v4-crt@3.398.0)(@babel/core@7.22.11)(builtin-modules@3.2.0)(typescript@5.2.2)
-      '@smithy/types':
-        specifier: ^2.2.2
-        version: 2.2.2
-      '@tsconfig/node16':
-        specifier: ^1.0.3
-        version: 1.0.3
-      '@types/adm-zip':
-        specifier: ^0.5.0
-        version: 0.5.0
-      '@types/aws-iot-device-sdk':
-        specifier: ^2.2.4
-        version: 2.2.4
-      '@types/aws-lambda':
-        specifier: ^8.10.108
-        version: 8.10.112
-      '@types/babel__core':
-        specifier: ^7.1.20
-        version: 7.20.0
-      '@types/babel__generator':
-        specifier: ^7.6.4
-        version: 7.6.4
-      '@types/cross-spawn':
-        specifier: ^6.0.2
-        version: 6.0.2
-      '@types/express':
-        specifier: ^4.17.14
-        version: 4.17.14
-      '@types/glob':
-        specifier: ^8.0.0
-        version: 8.0.0
-      '@types/node':
-        specifier: ^18.11.9
-        version: 18.15.3
-      '@types/react':
-        specifier: ^17.0.33
-        version: 17.0.52
-      '@types/uuid':
-        specifier: ^8.3.4
-        version: 8.3.4
-      '@types/ws':
-        specifier: ^8.5.3
-        version: 8.5.3
-      '@types/yargs':
-        specifier: ^17.0.13
-        version: 17.0.13
-      archiver:
-        specifier: ^5.3.1
-        version: 5.3.2
-      tsx:
-        specifier: ^3.12.1
-        version: 3.12.1
-      typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
-      vitest:
-        specifier: ^0.33.0
-        version: 0.33.0
-
   packages/svelte-kit-sst:
     devDependencies:
       '@sveltejs/kit':
@@ -1088,6 +799,7 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.19
+    dev: false
 
   /@astrojs/compiler@0.31.4:
     resolution: {integrity: sha512-6bBFeDTtPOn4jZaiD3p0f05MEGQL9pw2Zbfj546oFETNmjJFWO3nzHz6/m+P53calknCvyVzZ5YhoBLIvzn5iw==}
@@ -5495,6 +5207,7 @@ packages:
     dependencies:
       '@babel/highlight': 7.22.13
       chalk: 2.4.2
+    dev: false
 
   /@babel/compat-data@7.22.3:
     resolution: {integrity: sha512-aNtko9OPOwVESUFp3MZfD8Uzxl7JzSeJpd7npIoxCasU37PFbAQRpKglkaKwlHOyeJdrREpo8TW8ldrkYWwvIQ==}
@@ -5503,6 +5216,7 @@ packages:
   /@babel/compat-data@7.22.9:
     resolution: {integrity: sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==}
     engines: {node: '>=6.9.0'}
+    dev: false
 
   /@babel/core@7.12.9:
     resolution: {integrity: sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==}
@@ -5594,6 +5308,7 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/generator@7.20.4:
     resolution: {integrity: sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==}
@@ -5629,6 +5344,7 @@ packages:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.19
       jsesc: 2.5.2
+    dev: false
 
   /@babel/generator@7.22.3:
     resolution: {integrity: sha512-C17MW4wlk//ES/CJDL51kPNwl+qiBQyN7b9SKyVp11BLGFeSPoVaHrv+MNt8jwQFhQWowW88z1eeBx3pFz9v8A==}
@@ -5701,6 +5417,7 @@ packages:
       browserslist: 4.21.10
       lru-cache: 5.1.1
       semver: 6.3.1
+    dev: false
 
   /@babel/helper-create-class-features-plugin@7.22.1(@babel/core@7.20.2):
     resolution: {integrity: sha512-SowrZ9BWzYFgzUMwUmowbPSGu6CXL5MSuuCkG3bejahSpSymioPmuLdhPxNOc9MjuNGjy7M/HaXvJ8G82Lywlw==}
@@ -5859,6 +5576,7 @@ packages:
   /@babel/helper-environment-visitor@7.22.5:
     resolution: {integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==}
     engines: {node: '>=6.9.0'}
+    dev: false
 
   /@babel/helper-explode-assignable-expression@7.18.6:
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
@@ -5879,6 +5597,7 @@ packages:
     dependencies:
       '@babel/template': 7.22.5
       '@babel/types': 7.22.11
+    dev: false
 
   /@babel/helper-hoist-variables@7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
@@ -5891,6 +5610,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.11
+    dev: false
 
   /@babel/helper-member-expression-to-functions@7.18.9:
     resolution: {integrity: sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==}
@@ -5928,6 +5648,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.11
+    dev: false
 
   /@babel/helper-module-transforms@7.20.2:
     resolution: {integrity: sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==}
@@ -6000,6 +5721,7 @@ packages:
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.5
+    dev: false
 
   /@babel/helper-optimise-call-expression@7.18.6:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
@@ -6086,6 +5808,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.11
+    dev: false
 
   /@babel/helper-skip-transparent-expression-wrappers@7.20.0:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
@@ -6104,6 +5827,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.11
+    dev: false
 
   /@babel/helper-string-parser@7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
@@ -6132,6 +5856,7 @@ packages:
   /@babel/helper-validator-option@7.22.5:
     resolution: {integrity: sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==}
     engines: {node: '>=6.9.0'}
+    dev: false
 
   /@babel/helper-wrap-function@7.19.0:
     resolution: {integrity: sha512-txX8aN8CZyYGTwcLhlk87KRqncAzhh5TpQamZUa0/u3an36NtDpUP6bQgBCBcLeBs09R/OwQu3OjK0k/HwfNDg==}
@@ -6184,6 +5909,7 @@ packages:
       '@babel/types': 7.22.11
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/highlight@7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
@@ -6534,16 +6260,6 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-syntax-jsx@7.14.5(@babel/core@7.22.11):
-    resolution: {integrity: sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.22.11
-      '@babel/helper-plugin-utils': 7.21.5
-    dev: true
-
   /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.20.2):
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
     engines: {node: '>=6.9.0'}
@@ -6739,16 +6455,6 @@ packages:
     dependencies:
       '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.21.5
-
-  /@babel/plugin-syntax-typescript@7.21.4(@babel/core@7.22.11):
-    resolution: {integrity: sha512-xz0D39NvhQn4t4RNsHmDnnsaQizIlUkdtYvLs8La1BlfjQ6JEwxkJGeqJMW2tAXx+q6H+WFuUTXNdYVpEya0YA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.22.11
-      '@babel/helper-plugin-utils': 7.21.5
-    dev: false
 
   /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.20.2):
     resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
@@ -8348,6 +8054,7 @@ packages:
       '@babel/code-frame': 7.22.13
       '@babel/parser': 7.22.14
       '@babel/types': 7.22.11
+    dev: false
 
   /@babel/traverse@7.20.1:
     resolution: {integrity: sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==}
@@ -8417,6 +8124,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/traverse@7.22.4:
     resolution: {integrity: sha512-Tn1pDsjIcI+JcLKq1AVlZEr4226gpuAQTsLMorsYg9tuS/kG7nuwwJ4AB8jfQuEgb/COBwR/DqJxmoiYFu5/rQ==}
@@ -10280,6 +9988,7 @@ packages:
       '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
       graphql: 16.6.0
       tslib: 2.6.2
+    dev: false
 
   /@graphql-tools/schema@9.0.19(graphql@16.6.0):
     resolution: {integrity: sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==}
@@ -10310,6 +10019,7 @@ packages:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
       graphql: 16.6.0
       tslib: 2.6.2
+    dev: false
 
   /@graphql-typed-document-node/core@3.2.0(graphql@16.6.0):
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
@@ -10317,6 +10027,7 @@ packages:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.6.0
+    dev: false
 
   /@graphql-yoga/logger@0.0.1:
     resolution: {integrity: sha512-6npFz7eZz33mXgSm1waBLMjUNG0D5hTc/p5Hcs1mojkT3KsLpCOFokzTEKboNsBhKevYcaVa/xeA7WBj4UYMLg==}
@@ -11425,23 +11136,6 @@ packages:
       - webpack
     dev: true
 
-  /@sls-next/aws-common@3.7.0(@aws-sdk/signature-v4-crt@3.398.0)(@babel/core@7.22.11)(typescript@5.2.2):
-    resolution: {integrity: sha512-NNaJkBg+iJBlZW3pj4we3P6dzuLEMloWSnwzNXU518KGWvx7r3+2pD0kMe+LprTRBuOP82DCeYMHxncM3CvC+w==}
-    dependencies:
-      '@aws-sdk/client-s3': 3.54.0(@aws-sdk/signature-v4-crt@3.398.0)
-      '@aws-sdk/client-sqs': 3.54.0
-      '@sls-next/core': 3.7.0(@babel/core@7.22.11)(typescript@5.2.2)
-    transitivePeerDependencies:
-      - '@aws-sdk/signature-v4-crt'
-      - '@babel/core'
-      - fibers
-      - node-sass
-      - sass
-      - supports-color
-      - typescript
-      - webpack
-    dev: true
-
   /@sls-next/core@3.7.0(@babel/core@7.20.2)(typescript@5.2.2):
     resolution: {integrity: sha512-fCRV0iI84FboRk8YKATSFVp4dzR27zd6Rez/qfa4Utv9HL9UZbDTpKlyuUp24vEvADAZSp5laxj1JgOZBn2iOQ==}
     dependencies:
@@ -11471,35 +11165,6 @@ packages:
       - webpack
     dev: true
 
-  /@sls-next/core@3.7.0(@babel/core@7.22.11)(typescript@5.2.2):
-    resolution: {integrity: sha512-fCRV0iI84FboRk8YKATSFVp4dzR27zd6Rez/qfa4Utv9HL9UZbDTpKlyuUp24vEvADAZSp5laxj1JgOZBn2iOQ==}
-    dependencies:
-      '@hapi/accept': 5.0.2
-      cookie: 0.4.2
-      execa: 5.1.1
-      fast-glob: 3.2.11
-      fresh: 0.5.2
-      fs-extra: 9.1.0
-      is-animated: 2.0.2
-      jsonwebtoken: 8.5.1
-      next: 11.1.2(@babel/core@7.22.11)(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2)
-      node-fetch: 2.6.5
-      normalize-path: 3.0.0
-      path-to-regexp: 6.2.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      send: 0.17.2
-      sharp: 0.29.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - fibers
-      - node-sass
-      - sass
-      - supports-color
-      - typescript
-      - webpack
-    dev: true
-
   /@sls-next/lambda-at-edge@3.7.0(@aws-sdk/signature-v4-crt@3.398.0)(@babel/core@7.20.2)(builtin-modules@3.2.0)(typescript@5.2.2):
     resolution: {integrity: sha512-7eTqq1baZEuvEhexDchsP3QdOqPYaW123c7TupYB60Rs31KQ12xXvpzgn+mTMuFVIOQUDY5y8EKsuzYGRrQfcw==}
     hasBin: true
@@ -11510,35 +11175,6 @@ packages:
       '@aws-sdk/client-sqs': 3.54.0
       '@sls-next/aws-common': 3.7.0(@aws-sdk/signature-v4-crt@3.398.0)(@babel/core@7.20.2)(typescript@5.2.2)
       '@sls-next/core': 3.7.0(@babel/core@7.20.2)(typescript@5.2.2)
-      '@vercel/nft': 0.17.5
-      builtin-modules: 3.2.0
-      execa: 5.1.1
-      fs-extra: 9.1.0
-      get-stream: 6.0.1
-      node-fetch: 2.6.5
-      normalize-path: 3.0.0
-    transitivePeerDependencies:
-      - '@aws-sdk/signature-v4-crt'
-      - '@babel/core'
-      - encoding
-      - fibers
-      - node-sass
-      - sass
-      - supports-color
-      - typescript
-      - webpack
-    dev: true
-
-  /@sls-next/lambda-at-edge@3.7.0(@aws-sdk/signature-v4-crt@3.398.0)(@babel/core@7.22.11)(builtin-modules@3.2.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-7eTqq1baZEuvEhexDchsP3QdOqPYaW123c7TupYB60Rs31KQ12xXvpzgn+mTMuFVIOQUDY5y8EKsuzYGRrQfcw==}
-    hasBin: true
-    peerDependencies:
-      builtin-modules: 3.2.0
-    dependencies:
-      '@aws-sdk/client-s3': 3.54.0(@aws-sdk/signature-v4-crt@3.398.0)
-      '@aws-sdk/client-sqs': 3.54.0
-      '@sls-next/aws-common': 3.7.0(@aws-sdk/signature-v4-crt@3.398.0)(@babel/core@7.22.11)(typescript@5.2.2)
-      '@sls-next/core': 3.7.0(@babel/core@7.22.11)(typescript@5.2.2)
       '@vercel/nft': 0.17.5
       builtin-modules: 3.2.0
       execa: 5.1.1
@@ -13408,6 +13044,7 @@ packages:
       readdir-glob: 1.1.2
       tar-stream: 2.2.0
       zip-stream: 4.1.0
+    dev: false
 
   /are-we-there-yet@1.1.7:
     resolution: {integrity: sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==}
@@ -13782,7 +13419,7 @@ packages:
   /axios@0.24.0:
     resolution: {integrity: sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2(debug@4.3.4)
     transitivePeerDependencies:
       - debug
 
@@ -14269,6 +13906,7 @@ packages:
       electron-to-chromium: 1.4.523
       node-releases: 2.0.13
       update-browserslist-db: 1.0.11(browserslist@4.21.10)
+    dev: false
 
   /browserslist@4.21.5:
     resolution: {integrity: sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==}
@@ -17087,15 +16725,6 @@ packages:
     transitivePeerDependencies:
       - encoding
     dev: false
-
-  /follow-redirects@1.15.2:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
 
   /follow-redirects@1.15.2(debug@4.3.4):
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
@@ -20190,88 +19819,6 @@ packages:
       - webpack
     dev: true
 
-  /next@11.1.2(@babel/core@7.22.11)(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2):
-    resolution: {integrity: sha512-azEYL0L+wFjv8lstLru3bgvrzPvK0P7/bz6B/4EJ9sYkXeW8r5Bjh78D/Ol7VOg0EIPz0CXoe72hzAlSAXo9hw==}
-    engines: {node: '>=12.0.0'}
-    hasBin: true
-    peerDependencies:
-      fibers: '>= 3.1.0'
-      node-sass: ^4.0.0 || ^5.0.0
-      react: ^17.0.2
-      react-dom: ^17.0.2
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      fibers:
-        optional: true
-      node-sass:
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.15.3
-      '@hapi/accept': 5.0.2
-      '@next/env': 11.1.2
-      '@next/polyfill-module': 11.1.2
-      '@next/react-dev-overlay': 11.1.2(react-dom@17.0.2)(react@17.0.2)
-      '@next/react-refresh-utils': 11.1.2(react-refresh@0.8.3)
-      '@node-rs/helper': 1.2.1
-      assert: 2.0.0
-      ast-types: 0.13.2
-      browserify-zlib: 0.2.0
-      browserslist: 4.16.6
-      buffer: 5.6.0
-      caniuse-lite: 1.0.30001535
-      chalk: 2.4.2
-      chokidar: 3.5.1
-      constants-browserify: 1.0.0
-      crypto-browserify: 3.12.0
-      cssnano-simple: 3.0.0(postcss@8.2.15)
-      domain-browser: 4.19.0
-      encoding: 0.1.13
-      etag: 1.8.1
-      find-cache-dir: 3.3.1
-      get-orientation: 1.1.2
-      https-browserify: 1.0.0
-      image-size: 1.0.0
-      jest-worker: 27.0.0-next.5
-      native-url: 0.3.4
-      node-fetch: 2.6.1
-      node-html-parser: 1.4.9
-      node-libs-browser: 2.2.1
-      os-browserify: 0.3.0
-      p-limit: 3.1.0
-      path-browserify: 1.0.1
-      pnp-webpack-plugin: 1.6.4(typescript@5.2.2)
-      postcss: 8.2.15
-      process: 0.11.10
-      querystring-es3: 0.2.1
-      raw-body: 2.4.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      react-is: 17.0.2
-      react-refresh: 0.8.3
-      stream-browserify: 3.0.0
-      stream-http: 3.1.1
-      string_decoder: 1.3.0
-      styled-jsx: 4.0.1(@babel/core@7.22.11)(react@17.0.2)
-      timers-browserify: 2.0.12
-      tty-browserify: 0.0.1
-      use-subscription: 1.5.1(react@17.0.2)
-      util: 0.12.4
-      vm-browserify: 1.1.2
-      watchpack: 2.1.1
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 11.1.2
-      '@next/swc-darwin-x64': 11.1.2
-      '@next/swc-linux-x64-gnu': 11.1.2
-      '@next/swc-win32-x64-msvc': 11.1.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-      - typescript
-      - webpack
-    dev: true
-
   /nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
     dev: false
@@ -20427,6 +19974,7 @@ packages:
 
   /node-releases@2.0.13:
     resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
+    dev: false
 
   /nopt@4.0.3:
     resolution: {integrity: sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==}
@@ -23998,28 +23546,6 @@ packages:
       stylis-rule-sheet: 0.0.10(stylis@3.5.4)
     dev: true
 
-  /styled-jsx@4.0.1(@babel/core@7.22.11)(react@17.0.2):
-    resolution: {integrity: sha512-Gcb49/dRB1k8B4hdK8vhW27Rlb2zujCk1fISrizCcToIs+55B4vmUM0N9Gi4nnVfFZWe55jRdWpAqH1ldAKWvQ==}
-    engines: {node: '>= 12.0.0'}
-    peerDependencies:
-      '@babel/core': '*'
-      react: '>= 16.8.0 || 17.x.x || 18.x.x'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-    dependencies:
-      '@babel/core': 7.22.11
-      '@babel/plugin-syntax-jsx': 7.14.5(@babel/core@7.22.11)
-      '@babel/types': 7.15.0
-      convert-source-map: 1.7.0
-      loader-utils: 1.2.3
-      react: 17.0.2
-      source-map: 0.7.3
-      string-hash: 1.1.3
-      stylis: 3.5.4
-      stylis-rule-sheet: 0.0.10(stylis@3.5.4)
-    dev: true
-
   /stylehacks@5.1.1(postcss@8.4.19):
     resolution: {integrity: sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==}
     engines: {node: ^10 || ^12 || >=14.0}
@@ -24656,6 +24182,7 @@ packages:
     engines: {node: '>=14.0'}
     dependencies:
       busboy: 1.6.0
+    dev: true
 
   /unherit@1.1.3:
     resolution: {integrity: sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==}
@@ -24879,6 +24406,7 @@ packages:
       browserslist: 4.21.10
       escalade: 3.1.1
       picocolors: 1.0.0
+    dev: false
 
   /update-notifier@5.1.0:
     resolution: {integrity: sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==}
@@ -26084,6 +25612,7 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+    dev: true
 
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}


### PR DESCRIPTION
I am currently messing around with SST and deploying Rust lambda functions. Something Rust is infamously known for is it's slow compile times and I am really feeling this when working with Seed as the Rust must recompile on all stages (dev and for me multiple prod stages).

This PR adds an option called `prebuilt` that can be used to provide a prebuilt binary for the Lambda. I am pairing this with some custom caching code (backed by an S3 bucket) that allows me to only build the Lambda when the Rust code actually changes, letting me reuse the previously built binary when redeploying the same code to a different stage.

It can be used like the following:

```js
new Function(stack, "backend", {
  rust: {
    prebuild: "./target/lambda/main/bootstrap",
  },
});
```

