### PR TITLE
bug: Fixes Astro dependency in build

### DIFF
--- a/.changeset/kind-moose-allow.md
+++ b/.changeset/kind-moose-allow.md
@@ -1,0 +1,6 @@
+---
+"astro-sst": patch
+"sst": patch
+---
+
+Fixes build bug introduced with Astro-SST changes

--- a/.changeset/kind-moose-allow.md
+++ b/.changeset/kind-moose-allow.md
@@ -3,4 +3,4 @@
 "sst": patch
 ---
 
-Fixes build bug introduced with Astro-SST changes
+AstroSite: fixes build bug introduced with astro-sst changes

--- a/packages/astro-sst/src/lib/build-meta.ts
+++ b/packages/astro-sst/src/lib/build-meta.ts
@@ -8,7 +8,8 @@ import { join, relative } from "path";
 import { writeFile } from "fs/promises";
 import { fileURLToPath, parse } from "url";
 
-export const BUILD_META_FILE_NAME = "sst.buildMeta.json";
+export type BuildMetaFileName = "sst.buildMeta.json";
+export const BUILD_META_FILE_NAME: BuildMetaFileName = "sst.buildMeta.json";
 
 type BuildResults = {
   pages: {

--- a/packages/sst/src/constructs/AstroSite.ts
+++ b/packages/sst/src/constructs/AstroSite.ts
@@ -1,6 +1,6 @@
 import { readFileSync, existsSync, readdirSync, statSync } from "fs";
 import { join } from "path";
-import { BuildMetaConfig, BUILD_META_FILE_NAME } from "astro-sst/build-meta";
+import type { BuildMetaConfig, BuildMetaFileName } from "astro-sst/build-meta";
 import {
   Plan,
   SsrSite,
@@ -9,6 +9,8 @@ import {
 } from "./SsrSite.js";
 import { AllowedMethods } from "aws-cdk-lib/aws-cloudfront";
 import { Construct } from "constructs";
+
+const BUILD_META_FILE_NAME: BuildMetaFileName = "sst.buildMeta.json";
 
 export interface AstroSiteProps extends SsrSiteProps {
   regional?: SsrSiteProps["regional"] & {


### PR DESCRIPTION
Removes the `astro-sst` dependency from the `sst build` process.

Resolves #3377 