### PR TITLE
feat: Astro SSR response modes (buffered/streamed)

### DIFF
--- a/.changeset/empty-kangaroos-obey.md
+++ b/.changeset/empty-kangaroos-obey.md
@@ -1,0 +1,7 @@
+---
+"astro-sst": patch
+"sst": patch
+"@sst/docs": patch
+---
+
+Fixes Astro streaming

--- a/packages/astro-sst/src/edge/adapter.ts
+++ b/packages/astro-sst/src/edge/adapter.ts
@@ -1,5 +1,5 @@
 import type { AstroAdapter, AstroIntegration } from "astro";
-import { BuildMeta } from "../lib/build-meta";
+import { BuildMeta, IntegrationConfig } from "../lib/build-meta";
 
 const PACKAGE_NAME = "astro-sst/edge";
 
@@ -26,6 +26,13 @@ function getAdapter(): AstroAdapter {
 }
 
 export default function createIntegration(): AstroIntegration {
+  const integrationConfig: IntegrationConfig = {
+    responseMode: "buffer",
+    serverRoutes: [],
+  };
+
+  BuildMeta.setIntegrationConfig(integrationConfig);
+
   return {
     name: PACKAGE_NAME,
     hooks: {

--- a/packages/astro-sst/src/lambda/entrypoint.ts
+++ b/packages/astro-sst/src/lambda/entrypoint.ts
@@ -1,19 +1,36 @@
 import type { SSRManifest } from "astro";
 import type { APIGatewayProxyEventV2 } from "aws-lambda";
-import type { ResponseStream } from "../lib/types";
+import type { ResponseMode, ResponseStream } from "../lib/types";
 import { NodeApp } from "astro/app/node";
 import { polyfill } from "@astrojs/webapi";
-import { convertFrom, convertTo } from "../lib/event-mapper.js";
+import { InternalEvent, convertFrom, convertTo } from "../lib/event-mapper.js";
 import { debug } from "../lib/logger.js";
 
 polyfill(globalThis, {
   exclude: "window document",
 });
 
-export function createExports(manifest: SSRManifest) {
-  const app = new NodeApp(manifest);
+function createRequest(internalEvent: InternalEvent) {
+  const requestUrl = internalEvent.url;
+  const requestProps = {
+    method: internalEvent.method,
+    headers: internalEvent.headers,
+    body: ["GET", "HEAD"].includes(internalEvent.method)
+      ? undefined
+      : internalEvent.body,
+  };
+  debug("request", requestUrl, requestProps);
+  return new Request(requestUrl, requestProps);
+}
 
-  async function handler(
+export function createExports(
+  manifest: SSRManifest,
+  { responseMode }: { responseMode: ResponseMode }
+) {
+  const useStreaming = responseMode === "stream";
+  const app = new NodeApp(manifest, useStreaming);
+
+  async function streamHandler(
     event: APIGatewayProxyEventV2,
     responseStream: ResponseStream
   ) {
@@ -23,16 +40,7 @@ export function createExports(manifest: SSRManifest) {
     const internalEvent = convertFrom(event);
 
     // Build request
-    const requestUrl = internalEvent.url;
-    const requestProps = {
-      method: internalEvent.method,
-      headers: internalEvent.headers,
-      body: ["GET", "HEAD"].includes(internalEvent.method)
-        ? undefined
-        : internalEvent.body,
-    };
-    debug("request", requestUrl, requestProps);
-    const request = new Request(requestUrl, requestProps);
+    const request = createRequest(internalEvent);
 
     // Handle page not found
     const routeData = app.match(request, { matchNotFound: true });
@@ -50,20 +58,49 @@ export function createExports(manifest: SSRManifest) {
       response,
       responseStream,
       cookies: app.setCookieHeaders
-        ? (() => {
-            const cookies: string[] = [];
-            for (const header of app.setCookieHeaders(response)) {
-              cookies.push(header);
-            }
-            return cookies;
-          })()
+        ? Array.from(app.setCookieHeaders(response))
+        : undefined,
+    });
+  }
+
+  async function bufferHandler(event: APIGatewayProxyEventV2) {
+    debug("event", event);
+
+    // Parse Lambda event
+    const internalEvent = convertFrom(event);
+
+    // Build request
+    const request = createRequest(internalEvent);
+
+    // Handle page not found
+    const routeData = app.match(request, { matchNotFound: true });
+    if (!routeData) {
+      console.error("Not found");
+      return convertTo({
+        type: internalEvent.type,
+        response: new Response("Not found", { status: 404 }),
+      });
+    }
+
+    // Process request
+    const response = await app.render(request, routeData);
+    debug("response", response);
+
+    // Stream response back to Cloudfront
+    return convertTo({
+      type: internalEvent.type,
+      response,
+      cookies: app.setCookieHeaders
+        ? Array.from(app.setCookieHeaders(response))
         : undefined,
     });
   }
 
   return {
     // https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html
-    handler: awslambda.streamifyResponse(handler),
+    handler: useStreaming
+      ? awslambda.streamifyResponse(streamHandler)
+      : bufferHandler,
   };
 }
 

--- a/packages/astro-sst/src/lambda/entrypoint.ts
+++ b/packages/astro-sst/src/lambda/entrypoint.ts
@@ -27,6 +27,7 @@ export function createExports(
   manifest: SSRManifest,
   { responseMode }: { responseMode: ResponseMode }
 ) {
+  debug("handlerInit", { responseMode });
   const useStreaming = responseMode === "stream";
   const app = new NodeApp(manifest, useStreaming);
 
@@ -57,9 +58,7 @@ export function createExports(
       type: internalEvent.type,
       response,
       responseStream,
-      cookies: app.setCookieHeaders
-        ? Array.from(app.setCookieHeaders(response))
-        : undefined,
+      cookies: Array.from(app.setCookieHeaders(response))
     });
   }
 
@@ -86,13 +85,11 @@ export function createExports(
     const response = await app.render(request, routeData);
     debug("response", response);
 
-    // Stream response back to Cloudfront
-    return convertTo({
+    // Buffer response back to Cloudfront
+    return await convertTo({
       type: internalEvent.type,
       response,
-      cookies: app.setCookieHeaders
-        ? Array.from(app.setCookieHeaders(response))
-        : undefined,
+      cookies: Array.from(app.setCookieHeaders(response))
     });
   }
 

--- a/packages/astro-sst/src/lib/event-mapper.ts
+++ b/packages/astro-sst/src/lib/event-mapper.ts
@@ -13,7 +13,7 @@ import { debug } from "./logger.js";
 import { isBinaryContentType } from "./binary.js";
 import zlib from "zlib";
 
-type InternalEvent = {
+export type InternalEvent = {
   readonly type: "v1" | "v2" | "cf";
   readonly method: string;
   readonly queryString: string;

--- a/packages/astro-sst/src/lib/types.d.ts
+++ b/packages/astro-sst/src/lib/types.d.ts
@@ -36,3 +36,8 @@ export type RequestHandler = (
   context?: Context,
   callback?: Callback
 ) => void | Promise<void>;
+
+export type OutputMode = "server" | "static" | "hybrid";
+export type ResponseMode = "stream" | "buffer";
+export type PageResolution = "file" | "directory";
+export type TrailingSlash = "never" | "always" | "ignore";

--- a/packages/sst/src/constructs/AstroSite.ts
+++ b/packages/sst/src/constructs/AstroSite.ts
@@ -20,6 +20,7 @@ export interface AstroSiteProps extends SsrSiteProps {
      *   - "?" matches exactly 1 character.
      *
      * Matched routes will be handled directly by the server function.
+     * @deprecated Define `serverRoutes` in `astro.config.mjs` instead.
      * @default true
      * @example
      * ```js
@@ -34,17 +35,6 @@ export interface AstroSiteProps extends SsrSiteProps {
      * ```
      */
     serverRoutes?: string[];
-    /**
-     * Supports [streaming](https://docs.astro.build/en/guides/server-side-rendering/#using-streaming-to-improve-page-performance) responses.
-     * @default true
-     * @example
-     * ```js
-     * regional: {
-     *   streaming: false,
-     * }
-     * ```
-     */
-    streaming?: boolean;
   };
 }
 
@@ -89,7 +79,6 @@ export class AstroSite extends SsrSite {
         },
       ],
       regional: {
-        streaming: props?.regional?.streaming ?? true,
         ...props?.regional,
       },
     });
@@ -249,7 +238,7 @@ export class AstroSite extends SsrSite {
         type: "function",
         constructId: "ServerFunction",
         function: serverConfig,
-        streaming: regional?.streaming,
+        streaming: buildMeta.responseMode === "streaming",
       };
 
       plan.origins.fallthroughServer = {
@@ -271,7 +260,7 @@ export class AstroSite extends SsrSite {
           pattern: `${buildMeta.clientBuildVersionedSubDir}/*`,
           origin: "staticsServer",
         },
-        ...(regional?.serverRoutes ?? []).map(
+        ...(buildMeta.serverRoutes ?? regional?.serverRoutes ?? []).map(
           (route) =>
             ({
               cacheType: "server",

--- a/packages/sst/src/constructs/AstroSite.ts
+++ b/packages/sst/src/constructs/AstroSite.ts
@@ -238,7 +238,7 @@ export class AstroSite extends SsrSite {
         type: "function",
         constructId: "ServerFunction",
         function: serverConfig,
-        streaming: buildMeta.responseMode === "streaming",
+        streaming: buildMeta.responseMode === "stream",
       };
 
       plan.origins.fallthroughServer = {


### PR DESCRIPTION
Adds ability to specify response mode (`buffer` or `stream`) and sets up environment appropriately.

- Adds `responseMode` property to `astro-sst` adapter integration function.
- Moves `serverRoutes` property to `astro-sst` adapter integration function.
- Deprecates `serverRoutes` property on `AstroSite` constructor.

Response mode should be set in the adapter integration function call in `astro.config`:
```js
import { defineConfig } from "astro/config"
import aws from "astro-sst/lambda"

export default defineConfig({
  adapter: aws({
    responseMode: "stream",
    serverRoutes: [
      "feedback", // Feedback page which requires POST method
      "login",    // Login page which requires POST method
      "user/*",   // Directory of user routes which are all SSR
      "api/*"     // Directory of API endpoints which require all methods]
  })
})
```