### PR TITLE
fix: replace Promise.all with PutParametersCommand

### DIFF
--- a/.changeset/khaki-snakes-watch.md
+++ b/.changeset/khaki-snakes-watch.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Auth: batch delete keys on remove

--- a/packages/sst/support/custom-resources/auth-keys.ts
+++ b/packages/sst/support/custom-resources/auth-keys.ts
@@ -1,8 +1,8 @@
 import {
   SSMClient,
-  DeleteParameterCommand,
   GetParameterCommand,
   PutParameterCommand,
+  DeleteParametersCommand,
 } from "@aws-sdk/client-ssm";
 import crypto from "crypto";
 import { promisify } from "util";
@@ -94,18 +94,11 @@ export async function AuthKeys(cfnRequest: any) {
       }
       break;
     case "Delete":
-      await Promise.all([
-        client.send(
-          new DeleteParameterCommand({
-            Name: privatePath,
-          })
-        ),
-        client.send(
-          new DeleteParameterCommand({
-            Name: publicPath,
-          })
-        ),
-      ]);
+      await client.send(
+        new DeleteParametersCommand({
+          Names: [publicPath, privatePath],
+        })
+      );
       break;
     default:
       throw new Error("Unsupported request type");


### PR DESCRIPTION
I still need to fully test this in our project, but we get this error every time we try to remove a deployed stage:
```
2023-10-05T22:55:37.070Z	1c259060-9941-4cac-b547-7ee89d263211	INFO	[provider-framework] ThrottlingException: Rate exceeded
    at throwDefaultError (file:///var/task/index.mjs:9300:24)
    at file:///var/task/index.mjs:9310:39
    at de_DeleteParameterCommandError (file:///var/task/index.mjs:27053:18)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async file:///var/task/index.mjs:6243:24
    at async file:///var/task/index.mjs:3885:22
    at async file:///var/task/index.mjs:7495:42
    at async file:///var/task/index.mjs:1344:26
    at async Promise.all (index 0)
    at async AuthKeys (file:///var/task/index.mjs:179509:7) {
  '$fault': 'client',
  '$metadata': {
    httpStatusCode: 400,
    requestId: 'd6af2f3a-296d-4b45-a7b9-a0ecd5243616',
    extendedRequestId: undefined,
    cfId: undefined,
    attempts: 3,
    totalRetryDelay: 359
  },
  __type: 'ThrottlingException'
}
```

Hoping this fixes it.