### PR TITLE
feat: Adds layers to CDK props

### DIFF
--- a/.changeset/dirty-bees-taste.md
+++ b/.changeset/dirty-bees-taste.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Adds Lambda layer support to SSR Site

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -323,6 +323,7 @@ export interface SsrSiteProps {
     responseHeadersPolicy?: IResponseHeadersPolicy;
     server?: Pick<
       CdkFunctionProps,
+      | "layers"
       | "vpc"
       | "vpcSubnets"
       | "securityGroups"
@@ -622,7 +623,7 @@ export abstract class SsrSite extends Construct implements SSTConstruct {
         bind,
         environment,
         permissions,
-        // note: do not need to set vpc settings b/c this function is not being used
+        // note: do not need to set vpc and layers settings b/c this function is not being used
       });
     }
 


### PR DESCRIPTION
Adds layers as a CDK prop on the `SsrSite` construct to allow adding layers to Lambda functions.

Reference configurations:
```js
import { AstroSite } from 'sst/constructs'
import type { SSTConfig } from 'sst'
import * as lambda from 'aws-cdk-lib/aws-lambda'

const layerArn = 'arn:aws:lambda:us-west-2:764866452798:layer:chrome-aws-lambda:37'

export default {
  config() {
    return {
      name: 'test-website',
      region: 'us-west-2',
      profile: 'sst'
    }
  },
  stacks(app) {
    app.stack(function Site({ stack }) {
      const site = new AstroSite(stack, 'astro-site', {
        cdk: {
          server: {
            layers: [lambda.LayerVersion.fromLayerVersionArn(stack, 'ChromeLayer', layerArn)]
          }
        }
      })

      stack.addOutputs({
        url: site.customDomainUrl
      })
    })
  }
} satisfies SSTConfig
```
