### PR TITLE
bug: Fixes Astro site cache headers

### DIFF
--- a/.changeset/brown-ghosts-love.md
+++ b/.changeset/brown-ghosts-love.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Fixes AstroSite cache headers

--- a/packages/sst/src/constructs/AstroSite.ts
+++ b/packages/sst/src/constructs/AstroSite.ts
@@ -60,26 +60,6 @@ export class AstroSite extends SsrSite {
     super(scope, id, {
       ...props,
       typesPath: props?.typesPath ?? "src",
-      fileOptions: props?.fileOptions ?? [
-        {
-          exclude: "*",
-          include: "*.css",
-          cacheControl: "public,max-age=0,s-maxage=31536000,must-revalidate",
-          contentType: "text/css; charset=UTF-8",
-        },
-        {
-          exclude: "*",
-          include: "*.js",
-          cacheControl: "public,max-age=0,s-maxage=31536000,must-revalidate",
-          contentType: "application/javascript; charset=UTF-8",
-        },
-        {
-          exclude: "*",
-          include: "*.html",
-          cacheControl: "public,max-age=0,s-maxage=31536000,must-revalidate",
-          contentType: "text/html; charset=UTF-8",
-        },
-      ],
       regional: {
         ...props?.regional,
       },


### PR DESCRIPTION
Removes the `fileOptions` inserted by the `AstroSite` in favor of using the `SsrSite` default configuration using the S3 files as a mapping for the `fileOptions` configuration.

Resolves #3389 