### PR TITLE
AstroSite: Fixed invalid format for set-cookie headers in server response

### DIFF
--- a/.changeset/modern-pigs-push.md
+++ b/.changeset/modern-pigs-push.md
@@ -1,0 +1,5 @@
+---
+"astro-sst": patch
+---
+
+AstroSite: Fixed invalid format for set-cookie headers in server response

--- a/packages/astro-sst/src/lib/event-mapper.ts
+++ b/packages/astro-sst/src/lib/event-mapper.ts
@@ -157,7 +157,7 @@ export async function convertTo({
     cookies.push(...appCookies);
   }
   if (cookies.length > 0) {
-    headers["set-cookie"] = [cookies.join(";")];
+    headers["set-cookie"] = cookies;
   }
 
   // Parse isBase64Encoded


### PR DESCRIPTION
`set-cookie` headers were being incorrectly sent by the server, in this format:
```
set-cookie: Name=Value; Domain=xyz.com;Name2=Value2; Domain=xyz.com
```
This PR fixes it so they're properly returned in multiple headers:
```
set-cookie: Name=Value; Domain=xyz.com
set-cookie: Name2=Value2; Domain=xyz.com
```
This PR has been fully tested in a live staging environment.