### PR TITLE
fix: add delete parameters permissions to AuthKeys role

### DIFF
--- a/.changeset/soft-carpets-sell.md
+++ b/.changeset/soft-carpets-sell.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+fix: add delete parameters permissions to AuthKeys role

--- a/packages/sst/src/constructs/Auth.ts
+++ b/packages/sst/src/constructs/Auth.ts
@@ -114,6 +114,7 @@ export class Auth extends Construct implements SSTConstruct {
             "ssm:GetParameter",
             "ssm:PutParameter",
             "ssm:DeleteParameter",
+            "ssm:DeleteParameters",
           ],
           resources: [
             `arn:${stack.partition}:ssm:${stack.region}:${stack.account}:parameter/*`,

--- a/packages/sst/src/constructs/future/Auth.ts
+++ b/packages/sst/src/constructs/future/Auth.ts
@@ -147,6 +147,7 @@ export class Auth extends Construct implements SSTConstruct {
             "ssm:GetParameter",
             "ssm:PutParameter",
             "ssm:DeleteParameter",
+            "ssm:DeleteParameters",
           ],
           resources: [
             `arn:${stack.partition}:ssm:${stack.region}:${stack.account}:parameter/*`,


### PR DESCRIPTION
Forgot to add this in my previous PR. Using `DeleteParameters` actually fails without these permissions.