### PR TITLE
bug: Cookie header fix

### DIFF
--- a/.changeset/modern-pigs-push.md
+++ b/.changeset/modern-pigs-push.md
@@ -1,0 +1,5 @@
+---
+"astro-sst": patch
+---
+
+AstroSite: Fixed invalid format for set-cookie headers in server response

--- a/packages/astro-sst/src/lambda/entrypoint.ts
+++ b/packages/astro-sst/src/lambda/entrypoint.ts
@@ -51,15 +51,15 @@ export function createExports(
 
     // Process request
     const response = await app.render(request, routeData);
-    debug("response", response);
 
     // Stream response back to Cloudfront
-    await convertTo({
+    const result = await convertTo({
       type: internalEvent.type,
       response,
       responseStream,
-      cookies: Array.from(app.setCookieHeaders(response))
+      cookies: Array.from(app.setCookieHeaders(response)),
     });
+    debug("result", result);
   }
 
   async function bufferHandler(event: APIGatewayProxyEventV2) {
@@ -83,14 +83,15 @@ export function createExports(
 
     // Process request
     const response = await app.render(request, routeData);
-    debug("response", response);
 
     // Buffer response back to Cloudfront
-    return await convertTo({
+    const result = await convertTo({
       type: internalEvent.type,
       response,
-      cookies: Array.from(app.setCookieHeaders(response))
+      cookies: Array.from(app.setCookieHeaders(response)),
     });
+    debug("result", result);
+    return result;
   }
 
   return {

--- a/packages/astro-sst/src/lib/event-mapper.ts
+++ b/packages/astro-sst/src/lib/event-mapper.ts
@@ -157,7 +157,7 @@ export async function convertTo({
     cookies.push(...appCookies);
   }
   if (cookies.length > 0) {
-    headers["set-cookie"] = [cookies.join(";")];
+    headers["set-cookie"] = cookies;
   }
 
   // Parse isBase64Encoded

--- a/packages/astro-sst/src/lib/logger.ts
+++ b/packages/astro-sst/src/lib/logger.ts
@@ -1,5 +1,5 @@
 export function debug(...args: any[]) {
   if (process.env.SST_DEBUG) {
-    console.log(...args);
+    console.log(...args.map((arg) => JSON.stringify(arg, null, 2)));
   }
 }


### PR DESCRIPTION
This PR looks to solve the same problem as #3409 with a slight improvement on the handling of cookies for all environments.

The core issue of serialized cookies in a single response still exists for streamed responses, but this PR solves the issues for all other environments.

The streamed response issue seems to be a conflict between the spec and how browsers have implemented parsing. AWS does not support setting duplicate headers for streamed responses and the spec indicates a comma separated set is supported, but browsers utilizing Chromium don't seem to parse these headers correctly.