### PR TITLE
Options to speed up python builds

### DIFF
--- a/.changeset/pretty-tips-joke.md
+++ b/.changeset/pretty-tips-joke.md
@@ -1,0 +1,5 @@
+---
+"sst": major
+---
+
+Adds support for bypassing docker build for python (via an optional flag), and moves python file-copy processes to a place that can be async.

--- a/.changeset/pretty-tips-joke.md
+++ b/.changeset/pretty-tips-joke.md
@@ -1,5 +1,5 @@
 ---
-"sst": major
+"sst": minor
 ---
 
 Adds support for bypassing docker build for python (via an optional flag), and moves python file-copy processes to a place that can be async.

--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -538,6 +538,29 @@ export interface PythonProps {
    * ```
    */
   installCommands?: string[];
+
+  /**
+   * This options skips the python bundle step. If you set this flag to true, you must ensure
+   * that either:
+   *
+   * 1. your python build does not require dependencies
+   * 2. you have already installed production dependencies before running `sst deploy`.
+   *
+   * One solution to accomplish this is to pre-compile your production dependencies to some
+   * temporary directory, using pip's `--platform` argument to ensure python pre-built wheels are
+   * used and that your builds match your target lambda runtime, and use SST's `copyFiles`
+   * option to make sure these dependencies make it into your final deployment build.
+   *
+   * This can also help speed up python lambdas which do not have external dependencies. By
+   * default, SST will still run a docker file that is essentially a no-op if you have no
+   * dependencies. This option will bypass that step, even if you have a `Pipfile`, a `poetry.toml`,
+   * a `pyproject.toml`, or a `requirements.txt` (which would normally trigger an all-dependencies
+   * docker build).
+   *
+   * Enabling this option implies that you have accounted for all of the above and are handling
+   * your own build processes, and you are doing this for the sake of build optimization.
+   */
+  noDocker?: boolean;
 }
 
 /**

--- a/packages/sst/src/runtime/handlers/python.ts
+++ b/packages/sst/src/runtime/handlers/python.ts
@@ -9,6 +9,7 @@ import { Runtime } from "aws-cdk-lib/aws-lambda";
 import { bundle } from "./pythonBundling.js";
 import os from "os";
 import url from "url";
+import fs from "fs/promises";
 
 const RUNTIME_MAP: Record<string, Runtime> = {
   "python2.7": Runtime.PYTHON_2_7,
@@ -99,20 +100,23 @@ export const usePythonHandler = (): RuntimeHandler => {
           errors: [`Could not find src for ${input.props.handler}`],
         };
 
-      bundle({
-        installCommands: input.props.python?.installCommands,
-        entry: src,
-        runtime: RUNTIME_MAP[input.props.runtime!],
-        architecture: input.props.architecture,
-        outputPathSuffix: ".",
-        out: input.out,
-      });
-      /*
+      if (input.props.python?.noDocker !== true) {
+        bundle({
+          installCommands: input.props.python?.installCommands,
+          entry: src,
+          runtime: RUNTIME_MAP[input.props.runtime!],
+          architecture: input.props.architecture,
+          outputPathSuffix: ".",
+          out: input.out,
+        });
+      }
+
       await fs.cp(src, input.out, {
         recursive: true,
         filter: (src) => !src.includes(".sst"),
       });
 
+      /*
       if (await existsAsync(path.join(src, "Pipfile"))) {
         await execAsync("pipenv requirements > requirements.txt", {
           cwd: input.out,

--- a/packages/sst/src/runtime/handlers/pythonBundling.ts
+++ b/packages/sst/src/runtime/handlers/pythonBundling.ts
@@ -132,11 +132,6 @@ export function bundle(options: BundlingOptions & { out: string }) {
   if (hasDeps || hasInstallCommands) {
     image.cp(`${BUNDLER_DEPENDENCIES_CACHE}/.`, outputPath);
   }
-
-  // Copy source code to the bundle.
-  fs.cpSync(entry, outputPath, {
-    recursive: true,
-  });
 }
 
 /**


### PR DESCRIPTION
This makes a couple of minor changes to SST's python build logic which help drastically speed up python builds.

In our testing, without these changes, we can build about ~240 or so node.js lambdas in 150-160s. Adding 6 python lambdas adds 40-60s to this (just for `sst build`).

After weeks of investigation, the primary culprit seems to be async vs non-async work happening, combined with the way we use both SST and python. While `runtime/handlers/python.ts`'s `build()` IS async, all of the functions it calls within `pythonBundling.ts` are synchronous. The first thing I tried was making the functions in this file also async. This causes SST to explode because `useProject()` is called before `setProject()`. I'm not sure why, but because of CDK's involvement, that would only solve part of our problem.

There's a number of things that factor into what makes our python lambdas slow:

1. We at have more stacks and more lambdas than most (maybe all?) other SST consumers. With the synchronous calls mentioned above and described below, this doesn't just slow down our builds because of the python build speed -- it means that while python is bundling, all async tasks for building node lambdas are waiting for the sync tasks to finish.
2. The way we have our python configured, all six lambdas produce the exact same code bundle. After going through the process of building each through docker, `.sst/dist` contains only one `asset.*` directory with python code, and all of the python templates reference the same asset. 
3. The final step in `pythonBundling.ts`'s `bundle()` function is a `fs.cpSync()` call that happens at the end of the `bundle()` call. Moving this out of `bundle()` and back into the `async build()` and changing it to `await fs.cp()` shaves 25% off build times for us.
4. Also, within `pythonBundling.ts`'s `bundle()` function, a docker is used to build python dependencies.
    * This uses CDK's `DockerImage` construct, which is also synchronous. One alternative here would be to use the docker command line instead, and use asynchronous calls to execute the docker commands. That may be helpful for some users of python, but for reasons described below even THAT would be superfluous.
    * One of three Dockerfiles is chosen. The first step of all three is to install `rsync`. I think this is needed with certain ways of installing python dependencies, but it does not seem to be required for all.
        1. If the `installCommands` option is given, the Dockerfile first installs `rsync`, then upgrades `pip`, then installs `pipenv` and `poetry`, and then runs whatever `installCommands` we specified.
        2. If a `Pipfile`, `poetry.toml`, `pyproject.toml`, or `requirements.txt` is found, it does the `rsync`/`pip`/`pipenv`/`poetry` steps above, then tries to generate `requirements.txt` from either `Pipfile` or `poetry.lock`, and then finally installs from `requirements.txt` using `pip`. This makes what is, for us, a CRUCIAL mistake; our poetry is smart enough to have development and test dependencies grouped in a poetry `dev` and `test` group respectively, but excluding those from production builds requires passing `--without dev,test` to poetry. This docker does not do that when it creates `requirements.txt`, which means ~220mb of dependencies rather than ~40mb of dependencies.
        3. If neither of the above cases happen, a third Dockerfile (which as far as i can tell is completely unnecessary) installs `rsync`, then exits. I think that this exists so that the logic following can always assume SOME docker build file is needed.
    * We use wheels for our deployment packages. One of the features of wheels in python is that it downloads binary dependencies for the target architecture, regardless of whether the machine running the install command is running on that architecture. This means we don't need Docker to build python reliably. We can just install python+pip, and run `pip install --platform manylinux2014_x86_64 --implementation cp --only-binary=:all: -r "${REQS_FILE}" -t .`, and have all our production builds good to go with dependencies quickly.

So, our solution is:
1. This PR, allowing us to bypass the build process entirely, and making sure the file copy happens asynchronously
2. Before doing an `sst build` or `sst deploy`, we run a script that uses our `requirements.txt` to bundle all python dependencies (ONLY ONCE, before any build) to `[project-root]/.pydeps-deploy`. This happens in our CI, but we also allow developers to do a "qa-style" deploy to our own individual AWS accounts. We have a wrapper script that handles this process, and it can inject this "bundle all dependencies" first
3. We use, on ALL python lambdas, `copyFiles: [{ from: '.pydeps-deploy', to: '.' }]`. This ensures that all production dependencies are bundled into each file
4. We also set the `noDocker: true` to make sure that docker, and non-asynchronous work, is never involved in our build.

Using the above methodology? Our node builds if, we disable python entirely, run in 150-160s. Add the python builds back in, and they run in 150-160s. There is no noticeable difference between node and python lambdas in our build process anymore.