### PR TITLE
fix: support warming requests in remix server

### DIFF
--- a/packages/sst/support/remix-site-function/regional-server.js
+++ b/packages/sst/support/remix-site-function/regional-server.js
@@ -153,6 +153,16 @@ const createApigHandler = (build) => {
   const requestHandler = createNodeRequestHandler(build, process.env.NODE_ENV);
 
   return async (event) => {
+    if (event.type === "warmer") {
+      return {
+        statusCode: 200,
+        headers: {},
+        cookies: [],
+        body: JSON.stringify({ message: "warmed" }),
+        isBase64Encoded: false,
+      };
+    }
+
     const request = convertApigRequestToNode(event);
     const response = await requestHandler(request);
     return convertNodeResponseToApig(response);

--- a/packages/sst/support/remix-site-function/regional-server.js
+++ b/packages/sst/support/remix-site-function/regional-server.js
@@ -154,13 +154,7 @@ const createApigHandler = (build) => {
 
   return async (event) => {
     if (event.type === "warmer") {
-      return {
-        statusCode: 200,
-        headers: {},
-        cookies: [],
-        body: JSON.stringify({ message: "warmed" }),
-        isBase64Encoded: false,
-      };
+      return formatWarmerResponse(event);
     }
 
     const request = convertApigRequestToNode(event);
@@ -168,5 +162,13 @@ const createApigHandler = (build) => {
     return convertNodeResponseToApig(response);
   };
 };
+
+function formatWarmerResponse(event) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({ serverId });
+    }, event.delay);
+  });
+}
 
 export const handler = createApigHandler(remixServerBuild);


### PR DESCRIPTION
Open to suggestions on a better way to do this, but
https://github.com/sst/sst/blob/master/packages/sst/support/remix-site-function/regional-server.js#L84
throws an error when it receives a request from a warming function (event.headers is undefined)