### PR TITLE
fix(auth): update policy statement from DeleteParameter to DeleteParameters

### DIFF
--- a/.changeset/tender-shrimps-fix.md
+++ b/.changeset/tender-shrimps-fix.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+fix(auth): update policy statement from DeleteParameter to DeleteParameters

--- a/packages/sst/src/constructs/Auth.ts
+++ b/packages/sst/src/constructs/Auth.ts
@@ -113,7 +113,7 @@ export class Auth extends Construct implements SSTConstruct {
           actions: [
             "ssm:GetParameter",
             "ssm:PutParameter",
-            "ssm:DeleteParameter",
+            "ssm:DeleteParameters",
           ],
           resources: [
             `arn:${stack.partition}:ssm:${stack.region}:${stack.account}:parameter/*`,

--- a/packages/sst/src/constructs/future/Auth.ts
+++ b/packages/sst/src/constructs/future/Auth.ts
@@ -146,7 +146,7 @@ export class Auth extends Construct implements SSTConstruct {
           actions: [
             "ssm:GetParameter",
             "ssm:PutParameter",
-            "ssm:DeleteParameter",
+            "ssm:DeleteParameters",
           ],
           resources: [
             `arn:${stack.partition}:ssm:${stack.region}:${stack.account}:parameter/*`,


### PR DESCRIPTION
This PR updates the policy statement for the `CloudFrontInvalidatorPolicy` in the `Auth` construct.

https://github.com/sst/sst/pull/3382 changed a `Promise.all` call on two separate `DeleteParameter` commands to one single `DeleteParameters` command. However, because the policy statement was not updated, we are seeing this error when removing a stage with the `Auth` construct.

```
auth/StackMetadata: Received response status [FAILED] from custom resource. Message returned: User: arn:aws:sts::XXXXXXXXXXXX:assumed-role/pr85-embrace-AuthStack-CustomResourceHandlerService-i5GHPvO6PLiu/pr85-embrace-AuthStack-CustomResourceHandlerE8FB56-6lOiPCgvf1GH is not authorized to perform: ssm:DeleteParameters on resource: arn:aws:ssm:us-west-2:XXXXXXXXXXXX:parameter/sst/embrace/pr85/Auth/auth/publicKey because no identity-based policy allows the ssm:DeleteParameters action
```