### PR TITLE
sst: Create a `configPrefix` global option for the dev command

### DIFF
--- a/packages/sst/src/cli/program.ts
+++ b/packages/sst/src/cli/program.ts
@@ -23,11 +23,15 @@ export const program = yargs(hideBin(process.argv))
     type: "string",
     describe: "ARN of the IAM role to use when invoking AWS",
   })
+  .option("configPrefix", {
+    type: "string",
+    describe: "The custom prefix for the config file",
+  })
   .option("future", {
     type: "boolean",
     describe: "DO NOT USE. For enabling untested, experimental features",
   })
-  .group(["stage", "profile", "region", "role", "verbose", "help"], "Global:")
+  .group(["stage", "profile", "region", "role", "configPrefix", "verbose", "help"], "Global:")
   .middleware(async (argv) => {
     if (argv.verbose) {
       process.env.SST_VERBOSE = "1";

--- a/packages/sst/src/project.ts
+++ b/packages/sst/src/project.ts
@@ -100,21 +100,23 @@ interface GlobalOptions {
   stage?: string;
   root?: string;
   region?: string;
+  configPrefix?: string;
 }
 
 export async function initProject(globals: GlobalOptions) {
   // Logger.debug("initing project");
-  const root = globals.root || (await findRoot());
+  const root = globals.root || (await findRoot(globals));
   const out = path.join(root, ".sst");
   await fs.mkdir(out, {
     recursive: true,
   });
+  const configPrefix = `${globals.configPrefix}.sst` || "sst";
   // Logger.debug("made out dir");
 
   let file: string | undefined;
   const [metafile, sstConfig] = await (async function () {
     for (const ext of CONFIG_EXTENSIONS) {
-      file = path.join(root, "sst" + ext);
+      file = path.join(root, configPrefix + ext);
       if (!fsSync.existsSync(file)) continue;
       // Logger.debug("found sst config");
       const [metafile, config] = await load(file, true);
@@ -125,7 +127,7 @@ export async function initProject(globals: GlobalOptions) {
     throw new VisibleError(
       "Could not found a configuration file",
       "Make sure one of the following exists",
-      ...CONFIG_EXTENSIONS.map((x) => `  - sst${x}`)
+      ...CONFIG_EXTENSIONS.map((x) => `  - ${configPrefix}${x}`)
     );
   })();
 
@@ -257,16 +259,17 @@ async function promptPersonalStage(
   return await promptPersonalStage(out, true);
 }
 
-async function findRoot() {
+async function findRoot(globals: GlobalOptions) {
+  const configPrefix = `${globals.configPrefix}.sst` || "sst";
   async function find(dir: string): Promise<string> {
     if (dir === "/")
       throw new VisibleError(
         "Could not found a configuration file",
         "Make sure one of the following exists",
-        ...CONFIG_EXTENSIONS.map((ext) => `  - sst${ext}`)
+        ...CONFIG_EXTENSIONS.map((ext) => `  - ${configPrefix}${ext}`)
       );
     for (const ext of CONFIG_EXTENSIONS) {
-      const configPath = path.join(dir, `sst${ext}`);
+      const configPath = path.join(dir, `${configPrefix}${ext}`);
       if (fsSync.existsSync(configPath)) {
         return dir;
       }


### PR DESCRIPTION
I'm working on a monorepo that will define different configs in the same directory, and I noticed that we only allow 1 config.

This change will provide the option of specifying a prefix to the config file:
e.g.
```
sst dev --configPrefix web/
```
The previous command would look for the config at `web/sst.config.ts` instead of only ever having the option of `sst.config.ts`.

This way we can run the `sst dev` command from the root level and work on any sub-package