### PR TITLE
sst/examples/create-sst-rds: Add dynamic JSDoc database type to migration template

### DIFF
--- a/examples/create-sst-rds/_templates/migration/new/migration.ejs.t
+++ b/examples/create-sst-rds/_templates/migration/new/migration.ejs.t
@@ -4,13 +4,17 @@ to: packages/core/migrations/<%= Date.now() %>_<%= name.replace(/\s/g, "_") %>.m
 import { Kysely } from "kysely";
 
 /**
- * @param db {Kysely<any>}
+ * @typedef {import("../src/sql.generated").Database} Database
+ */
+
+/**
+ * @param db {Kysely<Database>}
  */
 export async function up(db) {
 }
 
 /**
- * @param db {Kysely<any>}
+ * @param db {Kysely<Database>}
  */
 export async function down(db) {
 }


### PR DESCRIPTION
# The problem

The `migration.ejs.t` file uses JSDoc to provide some autocompletion to the `db` type, but it doesn't make use of the auto-generated types in `sql.generated`.

This has led to some folks in the SST Discord (and myself) trying to set up TypeScript compilation for these files. But there is a simpler solution.

# The solution

JSDoc supports imported types from other files. This makes for some really nice autocompletion without requiring a separate build step or having to worry about anything happening with runtime of the migration itself.

![CleanShot 2023-10-30 at 17 30 19@2x](https://github.com/sst/sst/assets/5354479/791df7f8-f948-4742-9d57-30ea6f75dfd2)