### PR TITLE
fix: verifier on future/auth requires AUTH_ID

### DIFF
--- a/packages/sst/src/constructs/future/Auth.ts
+++ b/packages/sst/src/constructs/future/Auth.ts
@@ -194,6 +194,10 @@ export class Auth extends Construct implements SSTConstruct {
           type: "plain",
           value: this.url,
         },
+        authId: {
+          type: "auth_id",
+          value: this.id,
+        },
       },
       permissions: {},
     };

--- a/packages/sst/src/constructs/util/functionBinding.ts
+++ b/packages/sst/src/constructs/util/functionBinding.ts
@@ -40,6 +40,12 @@ export interface FunctionBindingProps {
         type: "site_url";
         value: string;
       }
+    | {
+        // used for future/auth as we need to pass in the auth_id with a
+        // specific environment name
+        type: "auth_id";
+        value: string;
+      }
   >;
 }
 
@@ -56,6 +62,8 @@ export function bindEnvironment(c: SSTConstruct) {
         environment[envName] = placeholderSecretValue();
       } else if (variable.type === "secret_reference") {
         environment[envName] = placeholderSecretReferenceValue(variable.secret);
+      } else if (variable.type === "auth_id") {
+        environment["AUTH_ID"] = variable.value;
       }
     });
   }


### PR DESCRIPTION
When using `future/auth` and using `session.use`, the publicKey is never returned as `process.env.AUTH_ID` is no longer defined. It used to be defined in previous auth through `auth.attach` which is no longer in the new version.

I thought it would be nicer to have it as part of the binding instead. So that we can just do the following and it should work:

```ts
new Api(stack, 'api', {
defaults: {
      function: {
        bind: [auth],
      },
    },
})
```

instead of currently which would be:

```ts
new Api(stack, 'api', {
defaults: {
      function: {
        environment: {
          AUTH_ID: auth.id,
        },
      },
    },
})
```