### PR TITLE
Added WASM mime type to S3 uploader

### DIFF
--- a/.changeset/old-pens-tell.md
+++ b/.changeset/old-pens-tell.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+StaticSite: set correct content type for wasm files

--- a/packages/sst/support/custom-resources/s3-uploader.ts
+++ b/packages/sst/support/custom-resources/s3-uploader.ts
@@ -262,6 +262,7 @@ function getContentType(filename: string, textEncoding: string) {
     [".xml"]: { mime: "application/xml", isText: true },
     [".pdf"]: { mime: "application/pdf", isText: false },
     [".zip"]: { mime: "application/zip", isText: false },
+    [".wasm"]: {  mime: "application/wasm", isText: false },
   };
   const extensionData = extensions[ext as keyof typeof extensions];
   const mime = extensionData?.mime ?? "application/octet-stream";


### PR DESCRIPTION
The recent change to the S3 uploader script dropped support for WASM files by default. I believe adding this line in to the extensions array will address the issue. 