### PR TITLE
Fix source maps documentation 

### DIFF
--- a/www/docs/advanced/source-maps.md
+++ b/www/docs/advanced/source-maps.md
@@ -15,7 +15,7 @@ new Function(stack, "MyFunction", {
   environment: {
     NODE_OPTIONS: "--enable-source-maps",
   },
-  bundle: {
+  nodejs: {
     sourcemap: true,
   },
 });
@@ -33,7 +33,7 @@ export default {
       environment: {
         NODE_OPTIONS: "--enable-source-maps",
       },
-      bundle: {
+      nodejs: {
         sourcemap: true,
       },
     });


### PR DESCRIPTION
`bundle` is not a valid property on `FunctionProps` object. Instead, there's `nodejs`