### PR TITLE
Add Sveltekit Warmer Response

### DIFF
--- a/packages/sst/support/ssr-warmer/index.ts
+++ b/packages/sst/support/ssr-warmer/index.ts
@@ -5,7 +5,7 @@ const lambda = new LambdaClient({});
 const FUNCTION_NAME = process.env.FUNCTION_NAME!;
 const CONCURRENCY = parseInt(process.env.CONCURRENCY!);
 
-function generateUniqueId() {
+export function generateUniqueId() {
   return Math.random().toString(36).slice(2, 8);
 }
 

--- a/packages/svelte-kit-sst/src/handler/index.ts
+++ b/packages/svelte-kit-sst/src/handler/index.ts
@@ -30,7 +30,7 @@ const serverId = `server-${generateUniqueId()}`;
 
 export async function handler(
   event: APIGatewayProxyEventV2 | CloudFrontRequestEvent | APIGatewayProxyEvent | WarmerEvent
-): Promise<any> {
+) {
   debug("event", event);
   // Handler warmer
   if ("type" in event) {


### PR DESCRIPTION
Issue:
When enabling `warm` on `SvelteKitSite` there is no handler for WarmerEvent and `convertFromAPIGatewayProxyEvent` handles the request generating the following error: 
```
Invoke Error	{
  "errorType": "TypeError",
  "errorMessage": "Cannot convert undefined or null to object",
  "stack": [
    "TypeError: Cannot convert undefined or null to object",
    "    at Function.entries (<anonymous>)",
    "    at normalizeAPIGatewayProxyEventHeaders (file:///var/task/app/.svelte-kit/svelte-kit-sst/server/lambda-handler/index.mjs:34401:39)",
    "    at convertFromAPIGatewayProxyEvent (file:///var/task/app/.svelte-kit/svelte-kit-sst/server/lambda-handler/index.mjs:34257:14)",
    "    at convertFrom (file:///var/task/app/.svelte-kit/svelte-kit-sst/server/lambda-handler/index.mjs:34233:12)",
    "    at Runtime.handler (file:///var/task/app/.svelte-kit/svelte-kit-sst/server/lambda-handler/index.mjs:34499:25)",
    "    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1173:29)"
  ]
}
``` 

Solution:
Implement pattern from  https://github.com/sst/open-next/blob/e32af92b30738a52066208b8ea39a71fdb3be67f/packages/open-next/src/adapters/plugins/lambdaHandler.ts#L25

Related:
- PR https://github.com/sst/sst/pull/3438,

