### PR TITLE
AppSyncApi: Improve multiple schema functionality.

### DIFF
--- a/.changeset/four-dingos-greet.md
+++ b/.changeset/four-dingos-greet.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+AppSyncApi: improve multiple schema functionality

--- a/packages/sst/src/constructs/AppSyncApi.ts
+++ b/packages/sst/src/constructs/AppSyncApi.ts
@@ -9,7 +9,7 @@ export async function weakImport(pkg: string) {
   }
 }
 
-const { print, buildSchema } = await weakImport("graphql");
+const { print } = await weakImport("graphql");
 const { mergeTypeDefs } = await weakImport("@graphql-tools/merge");
 
 import { Construct } from "constructs";
@@ -787,9 +787,7 @@ export class AppSyncApi extends Construct implements SSTConstruct {
         }
         // merge schema files
         const mergedSchema = mergeTypeDefs(
-          schema
-            .map((file) => fs.readFileSync(file).toString())
-            .map(buildSchema)
+          schema.map((file) => fs.readFileSync(file).toString())
         );
         const filePath = path.join(
           useProject().paths.out,


### PR DESCRIPTION
Currently, when using the `AppSyncApi` construct with multiple schema files, there's a few limitations due to passing each individual schema into the `buildSchema` function from `@graphql-tools/merge`.

- Sharing common types and enums etc between multiple schemas isn't possible as `buildSchema` treats each schema file separately
- `buildSchema` does not allow AppSync directives such as `@aws_iam`

Removing the call to `buildSchema` will fix both of the above limitations.

Related issues:
- https://github.com/sst/sst/issues/2104
- https://github.com/sst/sst/issues/2532