### PR TITLE
Auth: Prevent throwing on CDK id

### DIFF
--- a/.changeset/poor-cheetahs-approve.md
+++ b/.changeset/poor-cheetahs-approve.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Auth: Prevent throwing on CDK id

--- a/packages/sst/src/constructs/Auth.ts
+++ b/packages/sst/src/constructs/Auth.ts
@@ -94,7 +94,6 @@ export class Auth extends Construct implements SSTConstruct {
       "login" in props ||
       "triggers" in props ||
       "identityPoolFederation" in props ||
-      "cdk" in props
     ) {
       throw new Error(
         `It looks like you may be passing in Cognito props to the Auth construct. The Auth construct was renamed to Cognito in version 1.10.0`

--- a/packages/sst/src/constructs/Auth.ts
+++ b/packages/sst/src/constructs/Auth.ts
@@ -93,7 +93,7 @@ export class Auth extends Construct implements SSTConstruct {
       "defaults" in props ||
       "login" in props ||
       "triggers" in props ||
-      "identityPoolFederation" in props ||
+      "identityPoolFederation" in props
     ) {
       throw new Error(
         `It looks like you may be passing in Cognito props to the Auth construct. The Auth construct was renamed to Cognito in version 1.10.0`


### PR DESCRIPTION
The docs [mention](https://docs.sst.dev/constructs/Auth#cdkid) you can provide a cdk id to the auth construct.

But doing so results in an error during `sst build`

`It looks like you may be passing in Cognito props to the Auth construct. The Auth construct was renamed to Cognito in version 1.10.0`

Seems like cdk id was added as a prop after this throw and the throw was never cleaned up.

fixes: #3479 