### PR TITLE
Update default NodeJS runtime to 18.x

### DIFF
--- a/.changeset/thick-flowers-try.md
+++ b/.changeset/thick-flowers-try.md
@@ -1,0 +1,5 @@
+---
+"sst": minor
+---
+
+Function: update default runtime to Node.js 18

--- a/packages/sst/src/constructs/App.ts
+++ b/packages/sst/src/constructs/App.ts
@@ -187,7 +187,7 @@ export class App extends CDKApp {
    * @example
    * ```js
    * app.setDefaultFunctionProps({
-   *   runtime: "nodejs12.x",
+   *   runtime: "nodejs16.x",
    *   timeout: 30
    * })
    * ```

--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -64,7 +64,6 @@ const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 const supportedRuntimes = {
   container: CDKRuntime.FROM_IMAGE,
   rust: CDKRuntime.PROVIDED_AL2,
-  "nodejs12.x": CDKRuntime.NODEJS_12_X,
   "nodejs14.x": CDKRuntime.NODEJS_14_X,
   "nodejs16.x": CDKRuntime.NODEJS_16_X,
   "nodejs18.x": CDKRuntime.NODEJS_18_X,
@@ -196,12 +195,12 @@ export interface FunctionProps
   handler?: string;
   /**
    * The runtime environment for the function.
-   * @default "nodejs16.x"
+   * @default "nodejs18.x"
    * @example
    * ```js
    * new Function(stack, "Function", {
    *   handler: "function.handler",
-   *   runtime: "nodejs18.x",
+   *   runtime: "nodejs16.x",
    * })
    *```
    */
@@ -818,7 +817,7 @@ export class Function extends CDKFunction implements SSTConstruct {
       });
     }
     // Handle local development (ie. sst start)
-    // - set runtime to nodejs12.x for non-Node runtimes (b/c the stub is in Node)
+    // - set runtime to nodejs for non-Node runtimes (b/c the stub is in Node)
     // - set retry to 0. When the debugger is disconnected, the Cron construct
     //   will still try to periodically invoke the Lambda, and the requests would
     //   fail and retry. So when launching `sst start`, a couple of retry requests

--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -764,7 +764,7 @@ export class Function extends CDKFunction implements SSTConstruct {
       .forEach((per) => {
         props = Function.mergeProps(per, props);
       });
-    props.runtime = props.runtime || "nodejs16.x";
+    props.runtime = props.runtime || "nodejs18.x";
     if (props.runtime === "go1.x") useWarning().add("go.deprecated");
 
     // Set defaults

--- a/packages/sst/src/constructs/Job.ts
+++ b/packages/sst/src/constructs/Job.ts
@@ -738,6 +738,6 @@ export class Job extends Construct implements SSTConstruct {
 
   private convertJobRuntimeToFunctionRuntime() {
     const { runtime } = this.props;
-    return runtime === "container" ? "container" : "nodejs16.x";
+    return runtime === "container" ? "container" : "nodejs18.x";
   }
 }

--- a/packages/sst/src/constructs/deprecated/NextjsSite.ts
+++ b/packages/sst/src/constructs/deprecated/NextjsSite.ts
@@ -130,7 +130,7 @@ export interface NextjsSiteProps {
        * })
        *```
        */
-      runtime?: "nodejs12.x" | "nodejs14.x" | "nodejs16.x" | "nodejs18.x";
+      runtime?: "nodejs14.x" | "nodejs16.x" | "nodejs18.x";
     };
   };
   /**
@@ -1493,12 +1493,12 @@ export class NextjsSite extends Construct implements SSTConstruct {
   }
 
   private normalizeRuntime(runtime?: string): lambda.Runtime {
-    if (runtime === "nodejs12.x") {
-      return lambda.Runtime.NODEJS_12_X;
-    } else if (runtime === "nodejs14.x") {
+    if (runtime === "nodejs14.x") {
       return lambda.Runtime.NODEJS_14_X;
+    } else if (runtime === "nodejs16.x") {
+      return lambda.Runtime.NODEJS_16_X;
     }
-    return lambda.Runtime.NODEJS_16_X;
+    return lambda.Runtime.NODEJS_18_X;
   }
 }
 

--- a/www/docs/upgrade-guide.md
+++ b/www/docs/upgrade-guide.md
@@ -16,6 +16,16 @@ To view the latest release and all historical releases, <a href={`${config.githu
 
 ---
 
+## Upgrade to v2.35.0
+
+**The default runtime for functions has been updated from `nodejs16.x` to `nodejs18.x`** in response to AWS Lambda's deprecation announcement for the Node.js 16 runtime. To continue using Node.js 16, specify `nodejs16.x` as the default `runtime`.
+
+```diff
+app.setDefaultFunctionProps({
++ runtime: "nodejs16.x",
+});.
+```
+
 ## Upgrade to v2.34.0
 
 `AstroSite` now infers the `edge` mode from the `astro-sst` adapter. **Remove the `edge` prop from `AstroSite`.**


### PR DESCRIPTION
Solves the issue of default NodeJS being set to 16.x (causes `fetch` to fail since it was [introduced in 18.x](https://nodejs.org/en/blog/announcements/v18-release-announce#fetch-experimental))