### PR TITLE
(fix) Astro Adapter configuration override fix

### DIFF
--- a/.changeset/silent-balloons-peel.md
+++ b/.changeset/silent-balloons-peel.md
@@ -1,0 +1,5 @@
+---
+"astro-sst": patch
+---
+
+AstroSite: fixes bug with config override causing issues with MDX plugin

--- a/packages/astro-sst/src/adapter.ts
+++ b/packages/astro-sst/src/adapter.ts
@@ -106,9 +106,7 @@ export default function createIntegration(
         // Enable sourcemaps
         updateConfig({
           vite: {
-            ...config.vite,
             build: {
-              ...config.vite?.build,
               sourcemap: true,
             },
           },


### PR DESCRIPTION
Removes the config destructuring in the Astro adapter to fix issue with MDX plugin.