### PR TITLE
Make sourcemap order in CF templates deterministic

### DIFF
--- a/.changeset/nervous-rats-invite.md
+++ b/.changeset/nervous-rats-invite.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Make sourcemap ordering deterministic

--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -1379,7 +1379,11 @@ export const useFunctions = createAppContext(() => {
         arr.push(source);
       },
       forStack(stack: string) {
-        return sourcemaps[stack] || [];
+        return (sourcemaps[stack] || []).sort((a,b) => {
+          if (a.srcKey > b.srcKey) return 1;
+          if (a.srcKey < b.srcKey) return -1;
+          return 0;
+        });
       },
     },
     fromID(id: string) {

--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -981,6 +981,7 @@ export class Function extends CDKFunction implements SSTConstruct {
           });
           await fs.rm(result.sourcemap);
           useFunctions().sourcemaps.add(stack.stackName, {
+            sortKey: props.handler,
             srcBucket: asset.bucket,
             srcKey: asset.s3ObjectKey,
             tarKey: this.functionArn,
@@ -1368,6 +1369,7 @@ export const useFunctions = createAppContext(() => {
     srcBucket: IBucket;
     srcKey: string;
     tarKey: string;
+    sortKey: string;
   };
   const sourcemaps: Record<string, Sourcemap[]> = {};
 
@@ -1379,9 +1381,9 @@ export const useFunctions = createAppContext(() => {
         arr.push(source);
       },
       forStack(stack: string) {
-        return (sourcemaps[stack] || []).sort((a,b) => {
-          if (a.srcKey > b.srcKey) return 1;
-          if (a.srcKey < b.srcKey) return -1;
+        return (sourcemaps[stack] || []).sort((a, b) => {
+          if (a.sortKey > b.sortKey) return 1;
+          if (a.sortKey < b.sortKey) return -1;
           return 0;
         });
       },


### PR DESCRIPTION
When multiple lambdas in a stack have sourcemaps, the order of these sourcemaps within the CF template changes between runs. This means that:

* `sst diff` will show these as changes 
* `sst deploy` will needlessly redeploy these
* `sst start` also takes longer to fully deploy its stubs

Sorting the list of sourcemaps fixes this problem. This fix can be either applied inside `constructs/Function.ts` (in `useFunctions().sourcemaps.forStack()`) or `constructs/App.ts` (during the creation of the SourcemapUploader CustomResource). It seems cleaner to me to fix it in Function.ts, so this is the approach I took.