### PR TITLE
WebSocketApi: Support returnResponse in route definitions

### DIFF
--- a/.changeset/lazy-starfishes-lie.md
+++ b/.changeset/lazy-starfishes-lie.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+WebSocketApi: support route returnResponse

--- a/packages/sst/src/constructs/WebSocketApi.ts
+++ b/packages/sst/src/constructs/WebSocketApi.ts
@@ -194,6 +194,10 @@ export interface WebSocketApiFunctionRouteProps {
    *The function definition used to create the function for this route.
    */
   function: FunctionDefinition;
+  /**
+   *Enables two-way mode for this route.
+   */
+  returnResponse?: boolean;
 }
 
 /**
@@ -690,6 +694,7 @@ export class WebSocketApi extends Construct implements SSTConstruct {
         lambda
       ),
       authorizer: routeKey === "$connect" ? authorizer : undefined,
+      returnResponse: !Fn.isInlineDefinition(routeValue) && !!routeValue.returnResponse,
     });
 
     ///////////////////

--- a/packages/sst/src/constructs/WebSocketApi.ts
+++ b/packages/sst/src/constructs/WebSocketApi.ts
@@ -191,11 +191,11 @@ export interface WebSocketApiProps {
 export interface WebSocketApiFunctionRouteProps {
   type?: "function";
   /**
-   *The function definition used to create the function for this route.
+   * The function definition used to create the function for this route.
    */
   function: FunctionDefinition;
   /**
-   *Enables two-way mode for this route.
+   * Should the route send a response to the client.
    */
   returnResponse?: boolean;
 }
@@ -694,7 +694,9 @@ export class WebSocketApi extends Construct implements SSTConstruct {
         lambda
       ),
       authorizer: routeKey === "$connect" ? authorizer : undefined,
-      returnResponse: !Fn.isInlineDefinition(routeValue) && !!routeValue.returnResponse,
+      returnResponse: Fn.isInlineDefinition(routeValue)
+        ? undefined
+        : routeValue.returnResponse,
     });
 
     ///////////////////

--- a/packages/sst/test/constructs/WebSocketApi.test.ts
+++ b/packages/sst/test/constructs/WebSocketApi.test.ts
@@ -7,6 +7,7 @@ import {
   hasResource,
   objectLike,
   createApp,
+  printResource,
 } from "./helper";
 import * as acm from "aws-cdk-lib/aws-certificatemanager";
 import * as apig from "@aws-cdk/aws-apigatewayv2-alpha";
@@ -851,6 +852,41 @@ test("routes: route is prop", async () => {
   });
   hasResource(stack, "AWS::Lambda::Function", {
     Handler: "index.placeholder",
+  });
+});
+
+test("routes: route is prop: returnResponse default", async () => {
+  const stack = new Stack(await createApp(), "stack");
+  new WebSocketApi(stack, "Api", {
+    routes: {
+      $connect: {
+        function: {
+          handler: "test/lambda.handler",
+        },
+      },
+    },
+  });
+  printResource(stack, "AWS::ApiGatewayV2::Route");
+  countResourcesLike(stack, "AWS::ApiGatewayV2::Route", 1, {
+    RouteResponseSelectionExpression: ABSENT,
+  });
+});
+
+test("routes: route is prop: returnResponse true", async () => {
+  const stack = new Stack(await createApp(), "stack");
+  new WebSocketApi(stack, "Api", {
+    routes: {
+      $connect: {
+        function: {
+          handler: "test/lambda.handler",
+        },
+        returnResponse: true,
+      },
+    },
+  });
+  printResource(stack, "AWS::ApiGatewayV2::Route");
+  countResourcesLike(stack, "AWS::ApiGatewayV2::Route", 1, {
+    RouteResponseSelectionExpression: "$default",
   });
 });
 


### PR DESCRIPTION
We found need for two-way communications with our WebsocketApi's, and this seems to do the trick.  CDK had the wiring already, this PR exposes it via the routes.  Example:
```typescript
      const websocket = new WebSocketApi(stack, 'websocket', {
        routes: {
          echo: {
            function: {
              handler: 'server/websocket/echo.func'
            },
            // new:
            returnResponse: true
          },
        }
      });
```