### PR TITLE
Use new kyesly website URL in docs

### DIFF
--- a/packages/sst/src/constructs/RDS.ts
+++ b/packages/sst/src/constructs/RDS.ts
@@ -93,7 +93,7 @@ export interface RDSProps {
   };
 
   /**
-   * Path to the directory that contains the migration scripts. The `RDS` construct uses [Kysely](https://kysely-org.github.io/kysely/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
+   * Path to the directory that contains the migration scripts. The `RDS` construct uses [Kysely](https://kysely.dev/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
    *
    * @example
    *

--- a/www/docs/constructs/RDS.about.md
+++ b/www/docs/constructs/RDS.about.md
@@ -1,13 +1,13 @@
 The `RDS` construct is a higher level CDK construct that makes it easy to create an [RDS Serverless Cluster](https://aws.amazon.com/rds/). It uses the following defaults:
 
 - Defaults to using the [Serverless v1 On-Demand autoscaling configuration](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html) to make it serverless.
-- Provides a built-in interface for running schema migrations using [Kysely](https://koskimas.github.io/kysely/#migrations).
+- Provides a built-in interface for running schema migrations using [Kysely](https://kysely.dev/docs/migrations).
 - Enables [Data API](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html) to allow your Lambda functions to access the database cluster without needing to deploy the functions in a VPC (virtual private cloud).
 - Enables [Backup Snapshot](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/BackupRestoreAurora.html) to make sure that you don't lose your data.
 
 ## Migrations
 
-The `RDS` construct uses [Kysely](https://kysely-org.github.io/kysely/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
+The `RDS` construct uses [Kysely](https://kysely.dev/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
 
 ```js
 new RDS(stack, "Database", {
@@ -39,7 +39,7 @@ async function down(db) {
 module.exports = { up, down };
 ```
 
-[Read more about writing migrations](https://kysely-org.github.io/kysely/#migrations) over on the Kysely docs.
+[Read more about writing migrations](https://kysely.dev/docs/migrations) over on the Kysely docs.
 
 ### Migrations with PostgreSQL
 

--- a/www/docs/constructs/v0/RDS.md
+++ b/www/docs/constructs/v0/RDS.md
@@ -9,7 +9,7 @@ This is the SST v0.x Constructs doc. SST v1 is now released. If you are using v1
 The `RDS` construct is a higher level CDK construct that makes it easy to create an [RDS Serverless Cluster](https://aws.amazon.com/rds/). It uses the following defaults:
 
 - Defaults to using the [Serverless v1 On-Demand autoscaling configuration](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html) to make it serverless.
-- Provides a built-in interface for running schema migrations using [Kysely](https://koskimas.github.io/kysely/#migrations).
+- Provides a built-in interface for running schema migrations using [Kysely](https://kysely.dev/docs/migrations).
 - Enables [Data API](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html) to allow your Lambda functions to access the database cluster without needing to deploy the functions in a VPC (virtual private cloud).
 - Enables [Backup Snapshot](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/BackupRestoreAurora.html) to make sure that you don't lose your data.
 
@@ -80,7 +80,7 @@ new RDS(this, "Database", {
 });
 ```
 
-The `RDS` construct uses [Kysely](https://kysely-org.github.io/kysely/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
+The `RDS` construct uses [Kysely](https://kysely.dev/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
 
 On `sst deploy`, all migrations that have not yet been run will be run as a part of the deploy process. The migrations are executed in alphabetical order by their name.
 
@@ -146,7 +146,7 @@ async function down(db) {
 module.exports = { up, down };
 ```
 
-[Read more about writing migrations](https://kysely-org.github.io/kysely/#migrations) over on the Kysely docs.
+[Read more about writing migrations](https://kysely.dev/docs/migrations) over on the Kysely docs.
 
 ### Configuring the RDS cluster
 

--- a/www/docs/constructs/v1/RDS.about.md
+++ b/www/docs/constructs/v1/RDS.about.md
@@ -1,13 +1,13 @@
  The `RDS` construct is a higher level CDK construct that makes it easy to create an [RDS Serverless Cluster](https://aws.amazon.com/rds/). It uses the following defaults:
  
    - Defaults to using the [Serverless v1 On-Demand autoscaling configuration](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html) to make it serverless.
-   - Provides a built-in interface for running schema migrations using [Kysely](https://kysely-org.github.io/kysely/#migrations).
+   - Provides a built-in interface for running schema migrations using [Kysely](https://kysely.dev/docs/migrations).
    - Enables [Data API](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html) to allow your Lambda functions to access the database cluster without needing to deploy the functions in a VPC (virtual private cloud).
    - Enables [Backup Snapshot](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/BackupRestoreAurora.html) to make sure that you don't lose your data.
 
 ## Migrations
 
-The `RDS` construct uses [Kysely](https://kysely-org.github.io/kysely/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
+The `RDS` construct uses [Kysely](https://kysely.dev/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
 
 ```js
 new RDS(stack, "Database", {
@@ -39,7 +39,7 @@ async function down(db) {
 module.exports = { up, down };
 ```
 
-[Read more about writing migrations](https://koskimas.github.io/kysely/#migrations) over on the Kysely docs.
+[Read more about writing migrations](https://kysely.dev/docs/migrations) over on the Kysely docs.
 
 ### Migrations with PostgreSQL
 

--- a/www/docs/constructs/v1/RDS.tsdoc.md
+++ b/www/docs/constructs/v1/RDS.tsdoc.md
@@ -33,7 +33,7 @@ Database engine of the cluster. Cannot be changed once set.
 
 _Type_ : <span class="mono">string</span>
 
-Path to the directory that contains the migration scripts. The `RDS` construct uses [Kysely](https://kysely-org.github.io/kysely/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
+Path to the directory that contains the migration scripts. The `RDS` construct uses [Kysely](https://kysely.dev/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
 
 
 

--- a/www/docs/learn/index.md
+++ b/www/docs/learn/index.md
@@ -74,7 +74,7 @@ We also use a couple of other notable open-source libraries in our setup.
 
 ### Other libraries
 
-- [Kysely](https://kysely-org.github.io/kysely/), a typesafe TypeScript SQL query builder
+- [Kysely](https://kysely.dev/), a typesafe TypeScript SQL query builder
 - [Pothos](https://pothos-graphql.dev), a typesafe TypeScript GraphQL schema builder
 - [Urql](https://formidable.com/open-source/urql/) with [Genql](https://genql.vercel.app), a typesafe GraphQL client
 

--- a/www/docs/learn/initialize-the-database.md
+++ b/www/docs/learn/initialize-the-database.md
@@ -70,7 +70,7 @@ Recall from the [Project Structure](project-structure.md) chapter that the migra
 
 The starter creates the first migration for you. It's called `article` and you'll find it in `packages/core/migrations/1650000012557_article.mjs`.
 
-We use [Kysely](https://kysely-org.github.io/kysely/) to build our SQL queries in a typesafe way. We use that for our migrations as well.
+We use [Kysely](https://kysely.dev/) to build our SQL queries in a typesafe way. We use that for our migrations as well.
 
 ```js title="packages/core/migrations/1650000012557_article.mjs"
 import { Kysely } from "kysely";

--- a/www/docs/learn/write-to-the-database.md
+++ b/www/docs/learn/write-to-the-database.md
@@ -173,7 +173,7 @@ export function comments(articleID: string) {
 }
 ```
 
-We are using [Kysely](https://kysely-org.github.io/kysely/) to run typesafe queries against our database.
+We are using [Kysely](https://kysely.dev/) to run typesafe queries against our database.
 
 <details>
 <summary>Behind the scenes</summary>


### PR DESCRIPTION
Noticed some links weren't taking me to the correct pages, google showed some fancy new kysely site. Lets use that.

Replace all usages of the two old kysely URLs in documentation
[1](https://kysely-org.github.io/kysely/) [2](https://koskimas.github.io/kysely/#migrations)

With the new website found at https://kysely.dev/