### PR TITLE
Add _events and cb to the callback function in EventHandler

### DIFF
--- a/packages/sst/src/node/event-bus/index.ts
+++ b/packages/sst/src/node/event-bus/index.ts
@@ -146,7 +146,7 @@ export function EventHandler<Events extends Event>(
     }[Events["type"]]
   ) => Promise<void>
 ) {
-  return async (
+  const fn = async (
     event: EventBridgeEvent<string, any> & { attempts?: number }
   ) => {
     await cb({
@@ -156,4 +156,7 @@ export function EventHandler<Events extends Event>(
       attempts: event.attempts ?? 0,
     });
   };
+  fn._events = _events;
+  fn.cb = cb;
+  return fn;
 }

--- a/packages/sst/src/node/event-bus/index.ts
+++ b/packages/sst/src/node/event-bus/index.ts
@@ -156,7 +156,5 @@ export function EventHandler<Events extends Event>(
       attempts: event.attempts ?? 0,
     });
   };
-  fn._events = _events;
-  fn.cb = cb;
-  return fn;
+  return Object.assign(fn, { _events, cb });
 }


### PR DESCRIPTION
Add _events and cb to the callback function in EventHandler to make reflection easier.