### PR TITLE
sst/NextjsSite: Update NextjsSite.about.md

### DIFF
--- a/www/docs/constructs/NextjsSite.about.md
+++ b/www/docs/constructs/NextjsSite.about.md
@@ -291,7 +291,9 @@ To enable sourcemaps, make sure you are not disabling [`per-route` logging](#log
 ```diff title="next.config.js"
 const nextConfig = {
 + webpack: (config) => {
-+   config.devtool = "source-map";
++   if (!options.dev) {
++     config.devtool = "source-map";
++   }
 +   return config;
 + },
 };


### PR DESCRIPTION
When we applied the config in its original form, the Next dev mode reported:

> Warning: Reverting webpack devtool to 'eval-source-map'. Changing the webpack devtool in development mode will cause severe performance regressions.

The Next.js documentation suggests to avoid changing the devtool in dev mode: https://nextjs.org/docs/messages/improper-devtool