### PR TITLE
docs: Update events.md to include reference to createEventBuilder

### DIFF
--- a/www/docs/events.md
+++ b/www/docs/events.md
@@ -60,7 +60,11 @@ In your application you can define events. This definition provides validation u
 
 
 ```ts title="packages/core/src/todo.ts"
-import { event } from "./events";
+import { createEventBuilder } from "sst/node/event-bus";
+
+const event = createEventBuilder({
+  bus: "bus",
+});
 
 export const Events = {
   Created: event("todo.created", {
@@ -68,6 +72,11 @@ export const Events = {
   }),
 };
 ```
+
+:::info
+Note that the `"bus"` string passed to the `createEventBuilder` is the same ID as provided in the EventBus construct in MyStack.ts above
+:::
+
 ---
 
 ## Define subscriber


### PR DESCRIPTION
I couldn't find any reference to createEventBuilder anywhere in the docs site, and it took me spelunking in the Console repo to find out what i was missing creating Events

I don't really know the full ins and outs of how createEventBuilder worked so i added it as an example here rather than give a full section for it. 