### PR TITLE
Add optional resource type to function binding

### DIFF
--- a/packages/sst/src/constructs/Api.ts
+++ b/packages/sst/src/constructs/Api.ts
@@ -996,6 +996,7 @@ export class Api<
   public getFunctionBinding(): FunctionBindingProps {
     return {
       clientPackage: "api",
+      resourceType: 'Api',
       variables: {
         url: {
           type: "plain",

--- a/packages/sst/src/constructs/ApiGatewayV1Api.ts
+++ b/packages/sst/src/constructs/ApiGatewayV1Api.ts
@@ -797,6 +797,7 @@ export class ApiGatewayV1Api<
   public getFunctionBinding(): FunctionBindingProps {
     return {
       clientPackage: "api",
+      resourceType: 'ApiGatewayV1Api',
       variables: {
         url: {
           type: "plain",

--- a/packages/sst/src/constructs/App.ts
+++ b/packages/sst/src/constructs/App.ts
@@ -5,6 +5,7 @@ import { Stack } from "./Stack.js";
 import {
   SSTConstruct,
   SSTConstructMetadata,
+  SST_CONSTRUCT_TYPE,
   isSSTConstruct,
   isStackConstruct,
 } from "./Construct.js";
@@ -293,7 +294,7 @@ export class App extends CDKApp {
       return;
     }
 
-    const className = c.constructor.name;
+    const clientType = binding.clientType || c.constructor.name;
     const id = c.id;
 
     fs.appendFileSync(
@@ -303,7 +304,7 @@ export class App extends CDKApp {
           [
             `import "sst/node/${binding.clientPackage}";`,
             `declare module "sst/node/${binding.clientPackage}" {`,
-            `  export interface ${className}Resources {`,
+            `  export interface ${clientType}Resources {`,
             `    "${id}": string;`,
             `  }`,
             `}`,
@@ -313,7 +314,7 @@ export class App extends CDKApp {
         : [
             `import "sst/node/${binding.clientPackage}";`,
             `declare module "sst/node/${binding.clientPackage}" {`,
-            `  export interface ${className}Resources {`,
+            `  export interface ${clientType}Resources {`,
             `    "${id}": {`,
             ...binding.variables.map((p) => `      ${p}: string;`),
             `    }`,

--- a/packages/sst/src/constructs/AppSyncApi.ts
+++ b/packages/sst/src/constructs/AppSyncApi.ts
@@ -754,6 +754,7 @@ export class AppSyncApi extends Construct implements SSTConstruct {
 
     return {
       clientPackage: "api",
+      resourceType: "AppSyncApi",
       variables: {
         url: {
           type: "plain",

--- a/packages/sst/src/constructs/AstroSite.ts
+++ b/packages/sst/src/constructs/AstroSite.ts
@@ -253,4 +253,8 @@ export class AstroSite extends SsrSite {
       ...this.getConstructMetadataBase(),
     };
   }
+
+  public getBaseFunctionBindings() {
+    return this.createFunctionBinding('AstroSite');
+  }
 }

--- a/packages/sst/src/constructs/Auth.ts
+++ b/packages/sst/src/constructs/Auth.ts
@@ -150,6 +150,7 @@ export class Auth extends Construct implements SSTConstruct {
     const app = this.node.root as App;
     return {
       clientPackage: "auth",
+      resourceType: "Auth",
       variables: {
         publicKey: {
           type: "secret",

--- a/packages/sst/src/constructs/Bucket.ts
+++ b/packages/sst/src/constructs/Bucket.ts
@@ -480,6 +480,7 @@ export class Bucket extends Construct implements SSTConstruct {
   public getFunctionBinding(): FunctionBindingProps {
     return {
       clientPackage: "bucket",
+      resourceType: "Bucket",
       variables: {
         bucketName: {
           type: "plain",

--- a/packages/sst/src/constructs/Construct.ts
+++ b/packages/sst/src/constructs/Construct.ts
@@ -16,6 +16,7 @@ export interface SSTConstructMetadata<
   local?: L;
 }
 
+
 export interface SSTConstruct extends Construct {
   id: string;
   getConstructMetadata(): SSTConstructMetadata;

--- a/packages/sst/src/constructs/Cron.ts
+++ b/packages/sst/src/constructs/Cron.ts
@@ -2,7 +2,7 @@ import { Construct } from "constructs";
 import * as events from "aws-cdk-lib/aws-events";
 import * as eventsTargets from "aws-cdk-lib/aws-events-targets";
 
-import { getFunctionRef, SSTConstruct } from "./Construct.js";
+import { getFunctionRef, SST_CONSTRUCT_TYPE, SSTConstruct } from "./Construct.js";
 import { App } from "./App.js";
 import {
   Function as Func,

--- a/packages/sst/src/constructs/EventBus.ts
+++ b/packages/sst/src/constructs/EventBus.ts
@@ -584,6 +584,7 @@ export class EventBus extends Construct implements SSTConstruct {
   public getFunctionBinding(): FunctionBindingProps {
     return {
       clientPackage: "event-bus",
+      resourceType: "EventBus",
       variables: {
         eventBusName: {
           type: "plain",

--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -1133,6 +1133,7 @@ export class Function extends CDKFunction implements SSTConstruct {
   public getFunctionBinding(): FunctionBindingProps {
     return {
       clientPackage: "function",
+      resourceType: "Function",
       variables: {
         functionName: {
           type: "plain",

--- a/packages/sst/src/constructs/Job.ts
+++ b/packages/sst/src/constructs/Job.ts
@@ -380,6 +380,7 @@ export class Job extends Construct implements SSTConstruct {
   public getFunctionBinding(): FunctionBindingProps {
     return {
       clientPackage: "job",
+      resourceType: "Job",
       variables: {
         functionName: {
           type: "plain",

--- a/packages/sst/src/constructs/KinesisStream.ts
+++ b/packages/sst/src/constructs/KinesisStream.ts
@@ -315,6 +315,7 @@ export class KinesisStream extends Construct implements SSTConstruct {
   public getFunctionBinding(): FunctionBindingProps {
     return {
       clientPackage: "kinesis-stream",
+      resourceType: "KinesisStream",
       variables: {
         streamName: {
           type: "plain",

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -525,6 +525,10 @@ export class NextjsSite extends SsrSite {
     };
   }
 
+  public getFunctionBinding() {
+    return this.createFunctionBinding('NextjsSite');
+  }
+
   private wrapServerFunction(config: SsrFunctionProps | EdgeFunctionProps) {
     const { path: sitePath, experimental, cdk } = this.props;
     const stack = Stack.of(this);

--- a/packages/sst/src/constructs/Parameter.ts
+++ b/packages/sst/src/constructs/Parameter.ts
@@ -52,6 +52,7 @@ export class Parameter extends Construct implements SSTConstruct {
   public getFunctionBinding(): FunctionBindingProps {
     return {
       clientPackage: "config",
+      resourceType: "Parameter",
       variables: {
         value: {
           type: "plain",

--- a/packages/sst/src/constructs/Queue.ts
+++ b/packages/sst/src/constructs/Queue.ts
@@ -310,6 +310,7 @@ export class Queue extends Construct implements SSTConstruct {
   public getFunctionBinding(): FunctionBindingProps {
     return {
       clientPackage: "queue",
+      resourceType: "Queue",
       variables: {
         queueUrl: {
           type: "plain",

--- a/packages/sst/src/constructs/RDS.ts
+++ b/packages/sst/src/constructs/RDS.ts
@@ -316,6 +316,7 @@ export class RDS extends Construct implements SSTConstruct {
   public getFunctionBinding(): FunctionBindingProps {
     return {
       clientPackage: "rds",
+      resourceType: "RDS",
       variables: {
         clusterArn: {
           type: "plain",

--- a/packages/sst/src/constructs/RemixSite.ts
+++ b/packages/sst/src/constructs/RemixSite.ts
@@ -251,4 +251,8 @@ export class RemixSite extends SsrSite {
       ...this.getConstructMetadataBase(),
     };
   }
+
+  public getFunctionBinding() {
+    return this.createFunctionBinding('RemixSite');
+  }
 }

--- a/packages/sst/src/constructs/Secret.ts
+++ b/packages/sst/src/constructs/Secret.ts
@@ -49,6 +49,7 @@ export class Secret extends Construct implements SSTConstruct {
     const partition = Stack.of(this).partition;
     return {
       clientPackage: "config",
+      resourceType: "Secret",
       variables: {
         value: {
           type: "secret",

--- a/packages/sst/src/constructs/Service.ts
+++ b/packages/sst/src/constructs/Service.ts
@@ -723,6 +723,7 @@ export class Service extends Construct implements SSTConstruct {
     return this.distribution
       ? {
           clientPackage: "service",
+          resourceType: "Service",
           variables: {
             url: this.doNotDeploy
               ? {

--- a/packages/sst/src/constructs/SolidStartSite.ts
+++ b/packages/sst/src/constructs/SolidStartSite.ts
@@ -116,4 +116,8 @@ export class SolidStartSite extends SsrSite {
       ...this.getConstructMetadataBase(),
     };
   }
+
+  public getFunctionBinding() {
+    return this.createFunctionBinding('SolidStartSite');
+  }
 }

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -1492,10 +1492,13 @@ function handler(event) {
   >;
 
   /** @internal */
-  public getFunctionBinding(): FunctionBindingProps {
+  public abstract getFunctionBinding(): FunctionBindingProps;
+
+  protected createFunctionBinding(resourceType: string): FunctionBindingProps {
     const app = this.node.root as App;
     return {
       clientPackage: "site",
+      resourceType,
       variables: {
         url: this.doNotDeploy
           ? {

--- a/packages/sst/src/constructs/StaticSite.ts
+++ b/packages/sst/src/constructs/StaticSite.ts
@@ -456,6 +456,7 @@ export class StaticSite extends Construct implements SSTConstruct {
     const app = this.node.root as App;
     return {
       clientPackage: "site",
+      resourceType: "StaticSite",
       variables: {
         url: this.doNotDeploy
           ? {
@@ -798,7 +799,7 @@ interface ImportMeta {
 function handler(event) {
   var request = event.request;
   var uri = request.uri;
-  
+
   if (uri.startsWith("/.well-known/")) {
     return request;
   }

--- a/packages/sst/src/constructs/SvelteKitSite.ts
+++ b/packages/sst/src/constructs/SvelteKitSite.ts
@@ -162,4 +162,8 @@ export class SvelteKitSite extends SsrSite {
       ...this.getConstructMetadataBase(),
     };
   }
+
+  public getFunctionBinding() {
+    return this.createFunctionBinding('SvelteKitSite');
+  }
 }

--- a/packages/sst/src/constructs/Table.ts
+++ b/packages/sst/src/constructs/Table.ts
@@ -615,6 +615,7 @@ export class Table extends Construct implements SSTConstruct {
   public getFunctionBinding(): FunctionBindingProps {
     return {
       clientPackage: "table",
+      resourceType: "Table",
       variables: {
         tableName: {
           type: "plain",

--- a/packages/sst/src/constructs/Topic.ts
+++ b/packages/sst/src/constructs/Topic.ts
@@ -386,6 +386,7 @@ export class Topic extends Construct implements SSTConstruct {
   public getFunctionBinding(): FunctionBindingProps {
     return {
       clientPackage: "topic",
+      resourceType: "Topic",
       variables: {
         topicArn: {
           type: "plain",

--- a/packages/sst/src/constructs/WebSocketApi.ts
+++ b/packages/sst/src/constructs/WebSocketApi.ts
@@ -479,6 +479,7 @@ export class WebSocketApi extends Construct implements SSTConstruct {
   public getFunctionBinding(): FunctionBindingProps {
     return {
       clientPackage: "websocket-api",
+      resourceType: "WebSocketApi",
       variables: {
         url: {
           type: "plain",

--- a/packages/sst/src/constructs/util/functionBinding.ts
+++ b/packages/sst/src/constructs/util/functionBinding.ts
@@ -6,6 +6,7 @@ import { Config } from "../../config.js";
 
 export interface FunctionBindingProps {
   clientPackage: string;
+  resourceType?: string;
   permissions: Record<string, string[]>;
   variables: Record<
     string,
@@ -105,6 +106,7 @@ export function bindType(c: SSTConstruct) {
 
   return {
     clientPackage: binding.clientPackage,
+    clientType: binding.resourceType || undefined,
     variables: Object.keys(binding.variables),
   };
 }


### PR DESCRIPTION
Introducing an optional property called `resourceType` on function binding props so that we can explicitly define the resource type that should be used for type generation. This allows us to build custom SST constructs that can be injected into SST's type generation and variable population.

An example would be a custom database construct that can be bound to functions as well. Right now it would mean that we have to call the construct's class `RDS` just so that the types will be generated correctly and the variables are available via the `sst/node/rds` package. With the new property `resourceType` I can name my custom database construct however I want and can just set the `resourceType` in `getFunctionBinding` to `RDS` and the variables I define will be available via `sst/node/rds`.