### PR TITLE
refactor: skip logging ResponseURL as this contains an IAM access id

### DIFF
--- a/packages/sst/support/custom-resources/index.ts
+++ b/packages/sst/support/custom-resources/index.ts
@@ -18,7 +18,8 @@ export const handler = (event: any) => {
 };
 
 const customResourceEventHandler = wrapper(async (cfnRequest: any) => {
-  log("Handling custom resource event", cfnRequest);
+  const { ResponseURL, ...other } = cfnRequest;
+  log("Handling custom resource event", other);
 
   switch (cfnRequest.ResourceType) {
     case "Custom::AuthKeys":


### PR DESCRIPTION
Example ResponseURL:

  https://cloudformation-custom-resource-response-apsoutheast2.s3-ap-southeast-2.amazonaws.com/arn%3Aaws%3Acloudformation%3Aap-southeast-2%3A558125227772%3Astack/azure-graphql-wrapper-bdb/a91b0890-89d3-11ee-a54c-0ae0233cf359%7CSourcemapUploader%7Cffce58fd-405a-4bb7-8f41-d88e3d609c0f?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20231123T074157Z&X-Amz-SignedHeaders=host&X-Amz-Expires=7200&X-Amz-Credential=AKIA6MM33IIZWN5ZYINB%2F20231123%2Fap-southeast-2%2Fs3%2Faws4_request&X-Amz-Signature=2632a7e64578b4076a6d8eb9d735e1509b4e4dbfd325615bcf4af494f68176e2

Simply skip logging this, to avoid security flagging this as a potential issue, even though the access id by itself is not an issue.