### PR TITLE
generateMigrationsHash should not include all files - fix EISDIR error

### DIFF
--- a/.changeset/wicked-moose-remember.md
+++ b/.changeset/wicked-moose-remember.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+fix EISDIR error

--- a/packages/sst/src/constructs/RDS.ts
+++ b/packages/sst/src/constructs/RDS.ts
@@ -605,6 +605,7 @@ export class RDS extends Construct implements SSTConstruct {
       nodir: true,
       follow: true,
       cwd: migrations,
+      ignore: ["**/node_modules/**"],
     });
 
     // Calculate hash of all files content


### PR DESCRIPTION
After following the [RDS Migration guide](https://docs.sst.dev/constructs/RDS#migrations) I ended up creating a `package.json` inside `services/migration` in order to be able to add `import { Kysely, sql } from 'kysely'` inside my migration files.

After doing so, I started seeing the following error:
```haskell
Error: EISDIR: illegal operation on a directory, read

Trace: Error: EISDIR: illegal operation on a directory, read
    at Object.readSync (node:fs:751:3)
    at tryReadSync (node:fs:451:20)
    at Object.readFileSync (node:fs:497:19)
    at file:///node_modules/.pnpm/sst@2.36.7_@types+react@18.2.39/node_modules/sst/constructs/RDS.js:367:31
    at Array.map (<anonymous>)
    at RDS.generateMigrationsHash (file:///node_modules/.pnpm/sst@2.36.7_@types+react@18.2.39/node_modules/sst/constructs/RDS.js:367:14)
    at RDS.createMigrationCustomResource (file:///node_modules/.pnpm/sst@2.36.7_@types+react@18.2.39/node_modules/sst/constructs/RDS.js:341:52)
    at new RDS (file:///node_modules/.pnpm/sst@2.36.7_@types+react@18.2.39/node_modules/sst/constructs/RDS.js:64:18)
    at EmptyStack.Database (file:///frontend/.sst.config.1701332147477.mjs:13:10)
    at stack (file:///node_modules/.pnpm/sst@2.36.7_@types+react@18.2.39/node_modules/sst/constructs/FunctionalStack.js:20:35)
    at App.stack (file:///node_modules/.pnpm/sst@2.36.7_@types+react@18.2.39/node_modules/sst/constructs/App.js:500:16)
    at Object.stacks [as fn] (file:///frontend/.sst.config.1701332147477.mjs:117:9)
    at synthInRoot (file:///node_modules/.pnpm/sst@2.36.7_@types+react@18.2.39/node_modules/sst/stacks/synth.js:56:24)
    at async Module.synth (file:///node_modules/.pnpm/sst@2.36.7_@types+react@18.2.39/node_modules/sst/stacks/synth.js:19:16)
    at async buildApp (file:///node_modules/.pnpm/sst@2.36.7_@types+react@18.2.39/node_modules/sst/cli/commands/bind.js:84:13)
    at async Object.handler (file:///node_modules/.pnpm/sst@2.36.7_@types+react@18.2.39/node_modules/sst/cli/commands/bind.js:51:9)
    at process.<anonymous> (file:///node_modules/.pnpm/sst@2.36.7_@types+react@18.2.39/node_modules/sst/cli/sst.js:58:21)
    at process.emit (node:events:529:35)
    at process.emit (node:domain:489:12)
    at process._fatalException (node:internal/process/execution:158:25)
    at processPromiseRejections (node:internal/process/promises:288:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:96:32)
```

This happens because `generateMigrationsHash` has a very hungry glob pattern and eats up all the files from node_modules and whatever else it finds.

```js
    generateMigrationsHash(migrations) {
        // Get all files inside the migrations folder
        const files = globSync("**", {
            dot: true,
            nodir: true,
            follow: true,
            cwd: migrations,
        });
        ...
    }
```