### PR TITLE
feat(service): support configuration of Fargate Task ephemeral storage

### DIFF
--- a/.changeset/cuddly-kiwis-rhyme.md
+++ b/.changeset/cuddly-kiwis-rhyme.md
@@ -1,0 +1,6 @@
+---
+"sst": patch
+"@sst/docs": patch
+---
+
+feat(service): support configuration of ephemeral storage

--- a/.changeset/cuddly-kiwis-rhyme.md
+++ b/.changeset/cuddly-kiwis-rhyme.md
@@ -3,4 +3,4 @@
 "@sst/docs": patch
 ---
 
-feat(service): support configuration of ephemeral storage
+Service: support configuration of ephemeral storage

--- a/packages/sst/src/constructs/Service.ts
+++ b/packages/sst/src/constructs/Service.ts
@@ -230,7 +230,7 @@ export interface ServiceProps {
    * @example
    * ```js
    * {
-   *   storage: 100 GB,
+   *   storage: "100 GB",
    * }
    */
   storage?: `${number} GB`;

--- a/packages/sst/src/constructs/Service.ts
+++ b/packages/sst/src/constructs/Service.ts
@@ -232,6 +232,7 @@ export interface ServiceProps {
    * {
    *   storage: "100 GB",
    * }
+   * ```
    */
   storage?: `${number} GB`;
   /**

--- a/packages/sst/test/constructs/Service.test.ts
+++ b/packages/sst/test/constructs/Service.test.ts
@@ -253,19 +253,30 @@ test("memory invalid", async () => {
 test("storage undefined", async () => {
   const { stack } = await createService({});
   hasResource(stack, "AWS::ECS::TaskDefinition", {
-    ephemeralStorage: ABSENT,
+    EphemeralStorage: ABSENT,
+  });
+});
+test("storage default 20", async () => {
+  const { stack } = await createService({ storage: "20 GB" });
+  hasResource(stack, "AWS::ECS::TaskDefinition", {
+    EphemeralStorage: ABSENT,
   });
 });
 test("storage defined", async () => {
   const { stack } = await createService({ storage: "100 GB" });
   hasResource(stack, "AWS::ECS::TaskDefinition", {
-    ephemeralStorage: objectLike({ sizeInGiB: 100 }),
+    EphemeralStorage: objectLike({ SizeInGiB: 100 }),
   });
 });
-test("storage invalid", async () => {
+test("storage invalid too small", async () => {
   expect(async () => {
     await createService({ storage: "201 GB" });
-  }).rejects.toThrow(/the maximum supported value for storage/);
+  }).rejects.toThrow(/the supported value for storage/);
+});
+test("storage invalid too large", async () => {
+  expect(async () => {
+    await createService({ storage: "19 GB" });
+  }).rejects.toThrow(/the supported value for storage/);
 });
 
 test("port undefined", async () => {

--- a/packages/sst/test/constructs/Service.test.ts
+++ b/packages/sst/test/constructs/Service.test.ts
@@ -250,6 +250,19 @@ test("memory invalid", async () => {
   }).rejects.toThrow(/only the following "memory" settings/);
 });
 
+test("storage undefined", async () => {
+  const { stack } = await createService({});
+  hasResource(stack, "AWS::ECS::TaskDefinition", {
+    ephemeralStorage: ABSENT,
+  });
+});
+test("storage defined", async () => {
+  const { stack } = await createService({ storage: 21 });
+  hasResource(stack, "AWS::ECS::TaskDefinition", {
+    ephemeralStorage: objectLike({ sizeInGiB: 21 }),
+  });
+});
+
 test("port undefined", async () => {
   const { stack } = await createService({});
   hasResource(stack, "AWS::ECS::TaskDefinition", {

--- a/packages/sst/test/constructs/Service.test.ts
+++ b/packages/sst/test/constructs/Service.test.ts
@@ -257,10 +257,15 @@ test("storage undefined", async () => {
   });
 });
 test("storage defined", async () => {
-  const { stack } = await createService({ storage: 21 });
+  const { stack } = await createService({ storage: "100 GB" });
   hasResource(stack, "AWS::ECS::TaskDefinition", {
-    ephemeralStorage: objectLike({ sizeInGiB: 21 }),
+    ephemeralStorage: objectLike({ sizeInGiB: 100 }),
   });
+});
+test("storage invalid", async () => {
+  expect(async () => {
+    await createService({ storage: "201 GB" });
+  }).rejects.toThrow(/the maximum supported value for storage/);
 });
 
 test("port undefined", async () => {

--- a/www/docs/constructs/Service.about.md
+++ b/www/docs/constructs/Service.about.md
@@ -115,7 +115,7 @@ You may also configure the [amount of ephemeral storage allocated to the task](h
 ```js
 new Service(stack, "MyService", {
   path: "./service",
-  storage: 100,
+  storage: "100 GB",
 });
 ```
 

--- a/www/docs/constructs/Service.about.md
+++ b/www/docs/constructs/Service.about.md
@@ -110,6 +110,15 @@ new Service(stack, "MyService", {
 });
 ```
 
+You may also configure the [amount of ephemeral storage allocated to the task](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-storage.html). The default is 20 GB. To configure it, do the following:
+
+```js
+new Service(stack, "MyService", {
+  path: "./service",
+  storage: 100,
+});
+```
+
 ---
 
 ## Auto-scaling


### PR DESCRIPTION
This PR gives users of the `Service` construct the ability to configure the Fargate task [ephemeral storage](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-storage.html).

The pulled, compressed, and the uncompressed container image for the task is stored on the ephemeral storage. I would like to use a 3rd party image that is larger than the default 20 GB ephemeral storage. 

```
CannotPullContainerError: ref pull has been retried 1 time(s): failed to extract layer sha256:7c524a8642865c29df8d3973cefe8430653ba7fea85bd386e24e522601c30227: write /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/86/fs/home/notebook-user/.local/lib/python3.10/site-packages/numpy/linalg/__pycache__/linalg.cpython-310.pyc: no space left on device: unknown
```

As a result, being able to configure this value would be awesome