### PR TITLE
fix: init project doesn't replace stage

### DIFF
--- a/.changeset/calm-olives-joke.md
+++ b/.changeset/calm-olives-joke.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Calling init project does not replace stage if it was called previously

--- a/packages/sst/src/project.ts
+++ b/packages/sst/src/project.ts
@@ -131,9 +131,9 @@ export async function initProject(globals: GlobalOptions) {
 
   const config = await Promise.resolve(sstConfig.config(globals));
   const stage =
-    process.env.SST_STAGE ||
     globals.stage ||
     config.stage ||
+    process.env.SST_STAGE ||
     (await usePersonalStage(out)) ||
     (await promptPersonalStage(out));
   // Set stage to SST_STAGE so that if SST spawned processes are aware

--- a/packages/sst/src/util/lazy.ts
+++ b/packages/sst/src/util/lazy.ts
@@ -3,7 +3,7 @@ export function lazy<T>(callback: () => T) {
   let result: T;
 
   return () => {
-    if (!loaded) {
+    if (!loaded || process.env.SST_RESET_LAZY) {
       result = callback();
       loaded = true;
     }


### PR DESCRIPTION
So I noticed that when calling `initProject` twice, it seems to replace some values but not all of it.

Here's how to re-create it:
```ts
import { useProject, initProject } from 'sst/project';

await initProject({ stage: 'prod' });
const project = useProject();

console.log(project);

await initProject({ stage: 'justin' });
const project2 = useProject();

console.log(project2);
```

What I see logged out is that everything is the same between the 2 stages except for the `config.profile`. But if we deleted the `SST_STAGE` env variable before initiating the project a 2nd time, it works as expected. I think if we are passing in a config, it should take precedent before the `SST_STAGE` env variable. Either way, it's weird that the profile changes but not the stage.

My use case is: I'm writing a script that let's me migrate data between different environments. E.g. Migrate User Xs data from prod to dev, so that I can debug the issue. 