### PR TITLE
chore: Update Astro to v4

### DIFF
--- a/.changeset/warm-glasses-fail.md
+++ b/.changeset/warm-glasses-fail.md
@@ -1,0 +1,5 @@
+---
+"astro-sst": patch
+---
+
+astro-sst: update to Astro v4

--- a/packages/astro-sst/package.json
+++ b/packages/astro-sst/package.json
@@ -54,8 +54,8 @@
     "set-cookie-parser": "^2.6.0"
   },
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.112",
-    "@types/set-cookie-parser": "^2.4.3",
-    "astro": "^3.1.4"
+    "@types/aws-lambda": "^8.10.130",
+    "@types/set-cookie-parser": "^2.4.7",
+    "astro": "^4.0.2"
   }
 }

--- a/packages/astro-sst/src/entrypoint.ts
+++ b/packages/astro-sst/src/entrypoint.ts
@@ -47,7 +47,7 @@ export function createExports(
     const request = createRequest(internalEvent);
 
     // Handle page not found
-    const routeData = app.match(request, { matchNotFound: true });
+    const routeData = app.match(request);
     if (!routeData) {
       return streamError(404, "Not found", responseStream);
     }
@@ -78,7 +78,7 @@ export function createExports(
     const request = createRequest(internalEvent);
 
     // Handle page not found
-    const routeData = app.match(request, { matchNotFound: true });
+    const routeData = app.match(request);
     if (!routeData) {
       console.error("Not found");
       return convertTo({


### PR DESCRIPTION
Update Astro dev dependency to `v4` to confirm type compatibility.

PR tested with all templates from https://github.com/bayssmekanique/astro-sst-templates to confirm deployment support and all deployed successfully.

Resolve #3555 