### PR TITLE
fix: Pin bundled `sharp` version as hotfix

### DIFF
--- a/.changeset/nasty-pants-beam.md
+++ b/.changeset/nasty-pants-beam.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+SsrSite: pin bundled sharp version until deployment issues resolved

--- a/packages/sst/src/runtime/handlers/node.ts
+++ b/packages/sst/src/runtime/handlers/node.ts
@@ -256,12 +256,31 @@ export const useNodeHandler = (): RuntimeHandler => {
           );
           const cmd = ["npm install"];
           if (installPackages.includes("sharp")) {
+            /**
+             * TODO: This is a workaround for issues that sharp v0.33.0 has
+             * with cross platform builds. This can be removed once sharp
+             * releases a new version with the fix.
+             */
             cmd.push(
               "--platform=linux",
+              "--omit=dev",
+              "--no-optional",
               input.props.architecture === "arm_64"
                 ? "--arch=arm64"
-                : "--arch=x64"
+                : "--arch=x64",
+              "--force sharp@0.32.6"
             );
+            /**
+             * Once the above issue is resolved, the code below can be used.
+             */
+            // cmd.push(
+            //   "--platform=linux",
+            //   "--omit=dev",
+            //   "--no-optional",
+            //   ...input.props.architecture === "arm_64"
+            //     ? ["--arch=arm64", "--force @img/sharp-linux-arm64"]
+            //     : ["--arch=x64", "--force @img/sharp-linux-x64"],
+            // );
           }
           await new Promise<void>((resolve, reject) => {
             exec(cmd.join(" "), { cwd: input.out }, (error) => {


### PR DESCRIPTION
The most recent version of `sharp` (`v0.33.0`) is not stable for cross platform/architecture deployments. Pin the version to the last stable with a note to revert once issue is corrected.

Ref: https://github.com/lovell/sharp/issues/3870, https://github.com/lovell/sharp/issues/3884, https://github.com/lovell/sharp/issues/3872