### PR TITLE
docs: the route path was to .ts rather than the function name

### DIFF
--- a/examples/api-sst-auth-facebook/stacks/ExampleStack.ts
+++ b/examples/api-sst-auth-facebook/stacks/ExampleStack.ts
@@ -24,8 +24,8 @@ export function ExampleStack({ stack }: StackContext) {
       },
     },
     routes: {
-      "GET /": "packages/functions/src/auth.ts",
-      "GET /session": "packages/functions/src/session.ts",
+      "GET /": "packages/functions/src/auth.handler",
+      "GET /session": "packages/functions/src/session.handler",
     },
   });
 

--- a/examples/api-sst-auth-google/stacks/ExampleStack.ts
+++ b/examples/api-sst-auth-google/stacks/ExampleStack.ts
@@ -17,8 +17,8 @@ export function ExampleStack({ stack }: StackContext) {
       },
     },
     routes: {
-      "GET /": "packages/functions/src/auth.ts",
-      "GET /session": "packages/functions/src/session.ts",
+      "GET /": "packages/functions/src/auth.handler",
+      "GET /session": "packages/functions/src/session.handler",
     },
   });
 

--- a/packages/create-sst/bin/presets/examples/api-sst-auth-google/templates/stacks/ExampleStack.ts
+++ b/packages/create-sst/bin/presets/examples/api-sst-auth-google/templates/stacks/ExampleStack.ts
@@ -17,8 +17,8 @@ export function ExampleStack({ stack }: StackContext) {
       },
     },
     routes: {
-      "GET /": "packages/functions/src/auth.ts",
-      "GET /session": "packages/functions/src/session.ts",
+      "GET /": "packages/functions/src/auth.handler",
+      "GET /session": "packages/functions/src/session.handler",
     },
   });
 


### PR DESCRIPTION
The API route for `/` and `/session` went to `.ts` rather than the name of the function which is `handler`

Also, I am not 100% sure if `"GET /": "packages/functions/src/auth.ts"` in the API Construct are needed for these examples. 