### PR TITLE
fix: properly calculate content-length for cfn custom resource responses

### DIFF
--- a/.changeset/odd-windows-lick.md
+++ b/.changeset/odd-windows-lick.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Properly calculate content-length for cfn custom resource responses

--- a/packages/sst/support/certificate-requestor/index.mjs
+++ b/packages/sst/support/certificate-requestor/index.mjs
@@ -54,7 +54,7 @@ let report = function (
       method: "PUT",
       headers: {
         "Content-Type": "",
-        "Content-Length": responseBody.length,
+        "Content-Length": Buffer.byteLength(responseBody.length, "utf-8"),
       },
     };
 

--- a/packages/sst/support/custom-resources/cfn-response.ts
+++ b/packages/sst/support/custom-resources/cfn-response.ts
@@ -53,7 +53,7 @@ export async function submitResponse(
       method: "PUT",
       headers: {
         "content-type": "",
-        "content-length": responseBody.length,
+        "content-length": Buffer.byteLength(responseBody.length, "utf-8"),
       },
     },
     responseBody

--- a/packages/sst/support/edge-function/cfn-response.ts
+++ b/packages/sst/support/edge-function/cfn-response.ts
@@ -51,7 +51,7 @@ export async function submitResponse(
       method: "PUT",
       headers: {
         "content-type": "",
-        "content-length": responseBody.length,
+        "content-length": Buffer.byteLength(responseBody.length, "utf-8"),
       },
     },
     responseBody

--- a/packages/sst/support/script-function/cfn-response.ts
+++ b/packages/sst/support/script-function/cfn-response.ts
@@ -53,7 +53,7 @@ export async function submitResponse(
       method: "PUT",
       headers: {
         "content-type": "",
-        "content-length": responseBody.length,
+        "content-length": Buffer.byteLength(responseBody.length, "utf-8"),
       },
     },
     responseBody

--- a/packages/sst/support/sls-nextjs-site-function-code-replacer/lambda-code-updater.py
+++ b/packages/sst/support/sls-nextjs-site-function-code-replacer/lambda-code-updater.py
@@ -144,7 +144,7 @@ def cfn_send(event, context, responseStatus, responseData={}, physicalResourceId
 
     headers = {
         'content-type' : '',
-        'content-length' : str(len(body))
+        'content-length' : str(len(body.encode('utf-8')))
     }
 
     try:


### PR DESCRIPTION
Ref: https://github.com/aws/aws-cdk/pull/24501

> Custom Resources need to write their response into a S3 object.
> This is implemented as a PUT request to a pre-signed URL and has to specify the `content-length` of the response object.
> Previously the CustomResource code would use `responseBody.length`.
> However this returns the number of graphemes, not bytes.
> If any utf8 characters with `graphemes != bytes` are part of the response, CloudFormation would fail the deployment with a `Response is not valid JSON` error.

