### PR TITLE
fix: enforce target args in bundler

### DIFF
--- a/.changeset/plenty-laws-pay.md
+++ b/.changeset/plenty-laws-pay.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+SsrSite: fixes function bundler to match deployment target on bundled dependencies.

--- a/packages/sst/src/runtime/handlers/node.ts
+++ b/packages/sst/src/runtime/handlers/node.ts
@@ -255,29 +255,27 @@ export const useNodeHandler = (): RuntimeHandler => {
               ),
             })
           );
-          const cmd = ["npm install"];
+          const cmd = [
+            "npm install",
+            "--platform=linux",
+            "--omit=dev",
+            "--no-optional",
+            input.props.architecture === "arm_64"
+              ? "--arch=arm64"
+              : "--arch=x64",
+          ];
+
           if (installPackages.includes("sharp")) {
             /**
              * TODO: This is a workaround for issues that sharp v0.33.0 has
              * with cross platform builds. This can be removed once sharp
              * releases a new version with the fix.
              */
-            cmd.push(
-              "--platform=linux",
-              "--omit=dev",
-              "--no-optional",
-              input.props.architecture === "arm_64"
-                ? "--arch=arm64"
-                : "--arch=x64",
-              "--force sharp@0.32.6"
-            );
+            cmd.push("--force sharp@0.32.6");
             /**
              * Once the above issue is resolved, the code below can be used.
              */
             // cmd.push(
-            //   "--platform=linux",
-            //   "--omit=dev",
-            //   "--no-optional",
             //   ...input.props.architecture === "arm_64"
             //     ? ["--arch=arm64", "--force @img/sharp-linux-arm64"]
             //     : ["--arch=x64", "--force @img/sharp-linux-x64"],


### PR DESCRIPTION
As discussed in this [Discord thread](https://discord.com/channels/983865673656705025/1185483081621188638), many bundled dependencies like `libsql` require a platform specific binary. This PR enforces the platform specification for all `sst` built Node bundles with the passed in architecture.

This works fine for `sharp`, but it could use some testing with libraries that don't currently require binary files to ensure this does not create issues.