### PR TITLE
fix: SSR Edge function copyfile functionality

### DIFF
--- a/.changeset/dry-rocks-bake.md
+++ b/.changeset/dry-rocks-bake.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+EdgeFunction: fixes copyFile prop to actually copy files to deployed handler function.

--- a/packages/sst/src/constructs/EdgeFunction.ts
+++ b/packages/sst/src/constructs/EdgeFunction.ts
@@ -39,7 +39,11 @@ import { SSTConstruct } from "./Construct.js";
 import { App } from "./App.js";
 import { Stack } from "./Stack.js";
 import { Secret } from "./Config.js";
-import { useFunctions, NodeJSProps, FunctionCopyFilesProps } from "./Function.js";
+import {
+  useFunctions,
+  NodeJSProps,
+  FunctionCopyFilesProps,
+} from "./Function.js";
 import {
   bindEnvironment,
   bindPermissions,
@@ -196,7 +200,7 @@ export class EdgeFunction extends Construct {
           nodejs?.banner || "",
         ].join("\n"),
       },
-      copyFiles
+      copyFiles,
     });
 
     // Build function

--- a/packages/sst/src/constructs/EdgeFunction.ts
+++ b/packages/sst/src/constructs/EdgeFunction.ts
@@ -39,7 +39,7 @@ import { SSTConstruct } from "./Construct.js";
 import { App } from "./App.js";
 import { Stack } from "./Stack.js";
 import { Secret } from "./Config.js";
-import { useFunctions, NodeJSProps } from "./Function.js";
+import { useFunctions, NodeJSProps, FunctionCopyFilesProps } from "./Function.js";
 import {
   bindEnvironment,
   bindPermissions,
@@ -61,6 +61,7 @@ export interface EdgeFunctionProps {
   environment?: Record<string, string>;
   bind?: SSTConstruct[];
   nodejs?: NodeJSProps;
+  copyFiles?: FunctionCopyFilesProps[];
   scopeOverride?: IConstruct;
 }
 
@@ -98,10 +99,10 @@ export class EdgeFunction extends Construct {
     this.scope = props.scopeOverride || this;
 
     this.props = {
-      ...props,
       runtime: "nodejs18.x",
       timeout: 10,
       memorySize: 1024,
+      ...props,
       environment: props.environment || {},
       permissions: props.permissions || [],
     };
@@ -183,7 +184,7 @@ export class EdgeFunction extends Construct {
   }
 
   private async buildAssetFromHandler() {
-    const { nodejs } = this.props;
+    const { nodejs, copyFiles } = this.props;
 
     useFunctions().add(this.node.addr, {
       ...this.props,
@@ -195,6 +196,7 @@ export class EdgeFunction extends Construct {
           nodejs?.banner || "",
         ].join("\n"),
       },
+      copyFiles
     });
 
     // Build function

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -963,6 +963,7 @@ function handler(event) {
               ...environment,
               ...props.environment,
             },
+            ...cdk?.server,
           });
 
           bucket.grantReadWrite(fn.role!);


### PR DESCRIPTION
As discussed in this [Discord thread](https://discord.com/channels/983865673656705025/1184858611399278662), the SSR Edge deployments do not properly copy files dictated by the user as `props` on the construct (ie. `AstroSite`, `SsrSite`).

This PR ensures the `copyFile` property is passed all the way through to the function bundler, and when combined with #3588 resolves the issues noted by the reporting user in the thread.