### PR TITLE
fix: Astro greedy routes

### DIFF
--- a/.changeset/honest-vans-itch.md
+++ b/.changeset/honest-vans-itch.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Astro: fix greedy routes bug

--- a/packages/sst/src/constructs/AstroSite.ts
+++ b/packages/sst/src/constructs/AstroSite.ts
@@ -57,7 +57,7 @@ export class AstroSite extends SsrSite {
     
   var matchedRoute = findMatch(request.uri, routeData);
   if (matchedRoute) {
-    if (!matchedRoute[1]) {
+    if (!matchedRoute[1] && !/^.*\\.[^\\/]+$/.test(request.uri)) {
       ${
         pageResolution === "file"
           ? `request.uri = request.uri === "/" ? "/index.html" : request.uri.replace(/\\/?$/, ".html");`


### PR DESCRIPTION
This PR resolves #3601, preventing Astro route paths with very greedy RegEx values from capturing requests for static files by testing for a file extension in the CF Function and preventing rewrites if an extension is present.

Example routing before implementation of this PR:
`/fr` => `/fr/index.html`
`/sitemap-index.xml` => `/sitemap-index.xml/index.html`

Example routing after implementing this PR:
`/fr` => `/fr/index.html`
`sitema-index.xml` => `/sitemap-index.xml` (*unchanged*)

The only breaking change I can foresee with this change is if someone were to have implemented a false mime-type endpoint using the static rendering function (`/file.png` => `/file.png/index.html`) to serve an HTML page from a URL that appears to point to an asset. I can't see the value in doing this, so I'm assuming it's safe to abandon this functionality to resolve issues with i18n libraries.