### PR TITLE
Fix typo in Cognito.about.md

### DIFF
--- a/www/docs/constructs/Cognito.about.md
+++ b/www/docs/constructs/Cognito.about.md
@@ -162,7 +162,7 @@ const auth = new Cognito(stack, "Auth", {
   },
 });
 
-auth.attachPermissionsForTriggers("preAuthentication", ["s3"]);
+auth.attachPermissionsForTrigger("preAuthentication", ["s3"]);
 ```
 
 Here we are referring to the trigger using the trigger key, `preAuthentication`.


### PR DESCRIPTION
when specifying a specific trigger, the method is called `attachPermissionsForTrigger`, not `attachPermissionsForTriggers`