### PR TITLE
[SsrSite/NextjsSite]: Add cdk server configuration to ImageOptimizationFunction in SsrSite base construct

### DIFF
--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -1067,6 +1067,7 @@ function handler(event) {
           }),
         ],
         ...props.function,
+        ...cdk?.server,
       });
 
       const fnUrl = fn.addFunctionUrl({


### PR DESCRIPTION
`enhancement` (?)

See https://github.com/sst/sst/issues/3607, this provides a fix for that issue in the NextjsSite construct where VPC configuration is only applied to the origins of `type: 'function'` (see [this](https://github.com/sst/sst/blob/master/packages/sst/src/constructs/SsrSite.ts#L1098C1-L1100) and [this](https://github.com/sst/sst/blob/master/packages/sst/src/constructs/SsrSite.ts#L1010)), but not the image optimization function (see [this](https://github.com/sst/sst/blob/master/packages/sst/src/constructs/SsrSite.ts#L1101-L1102) and [this](https://github.com/sst/sst/blob/master/packages/sst/src/constructs/SsrSite.ts#L1057-L1070)).

All constructs inheriting from the `SsrSite` construct will inherit this change. Hoping for confirmation from a reviewer that this is desirable.