### PR TITLE
docs: Updates AWS auth action version and role-duration-seconds in GitHub actions example

### DIFF
--- a/www/docs/going-to-production.md
+++ b/www/docs/going-to-production.md
@@ -137,7 +137,7 @@ To setup OpenID Connect manually:
           - name: Git clone the repository
             uses: actions/checkout@v3
           - name: Configure AWS credentials
-            uses: aws-actions/configure-aws-credentials@v2
+            uses: aws-actions/configure-aws-credentials@v3
             with:
               role-to-assume: arn:aws:iam::1234567890:role/GitHub
               role-duration-seconds: 3600 #adjust as needed for your build time

--- a/www/docs/going-to-production.md
+++ b/www/docs/going-to-production.md
@@ -140,7 +140,7 @@ To setup OpenID Connect manually:
             uses: aws-actions/configure-aws-credentials@v2
             with:
               role-to-assume: arn:aws:iam::1234567890:role/GitHub
-              role-duration-seconds: 14390 #adjust as needed for your build time
+              role-duration-seconds: 3600 #adjust as needed for your build time
               aws-region: us-east-1
           - name: Deploy app
             run: |


### PR DESCRIPTION
Updates the AWS authorization GitHub Action version and the role-duration-seconds on the Going to Production docs page to match up with the default 1 hour time that AWS places on new IAM roles.

This might cut down on the debugging time for people like me that cut and paste the examples in the docs :)