### PR TITLE
[SsrSite/NextjsSite]: Add optional disableCloudFrontFunctions to SSRSite

### DIFF
--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -278,7 +278,7 @@ export class NextjsSite extends SsrSite {
     this.removeSourcemaps();
     return this.validatePlan({
       edge: edge ?? false,
-      cloudFrontFunctions: {
+      cloudFrontFunctions: cdk.disableCloudFrontFunctions ? undefined : {
         serverCfFunction: {
           constructId: "CloudFrontFunction",
           injections: [this.useCloudFrontFunctionHostHeaderInjection()],

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -464,6 +464,17 @@ export interface SsrSiteProps {
      * ```
      */
     viewerProtocolPolicy?: ViewerProtocolPolicy;
+    /**
+     * Disable the CloudFront functions that are used to implement SSR.
+     * @default
+     * By default, the CloudFront functions are enabled for host header injection.
+     * @example
+     * ```js
+     * cdk: {
+     *  disableCloudFrontFunctions: true,
+     * }
+     */
+    disableCloudFrontFunctions?: boolean;
     server?: Pick<
       CdkFunctionProps,
       | "layers"


### PR DESCRIPTION
This PR aims to add an optional parameter `disableCloudFrontFunctions` to avoid creating cloudfront functions when it is not needed. One of the use-case is that we may use SSR deployment with another CDN than Cloudfront (Cloudflare). In this case, host header is not needed in Cloudfront