### PR TITLE
Allow setting nodejs version of container image in jobs construct

### DIFF
--- a/.changeset/lazy-tools-float.md
+++ b/.changeset/lazy-tools-float.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Job: Allow setting nodejs version of container image

--- a/packages/sst/src/constructs/Job.ts
+++ b/packages/sst/src/constructs/Job.ts
@@ -596,8 +596,8 @@ export class Job extends Construct implements SSTConstruct {
       const image = LinuxBuildImage.fromDockerRegistry(
         // ARM images can be found here https://hub.docker.com/r/amazon/aws-lambda-nodejs
         architecture === "arm_64"
-          ? "amazon/aws-lambda-nodejs:16.2023.07.13.14"
-          : "amazon/aws-lambda-nodejs:16"
+          ? "amazon/aws-lambda-nodejs:18.2023.12.14.13"
+          : "amazon/aws-lambda-nodejs:18"
       );
       project.environment = {
         ...project.environment,

--- a/packages/sst/src/constructs/Job.ts
+++ b/packages/sst/src/constructs/Job.ts
@@ -108,7 +108,7 @@ export interface JobProps {
    * })
    *```
    */
-  runtime?: "nodejs" | "container";
+  runtime?: "nodejs16.x" | "nodejs18.x" | "nodejs20.x" | "container";
   /**
    * For "nodejs" runtime, point to the entry point and handler function.
    * Of the format: `/path/to/file.function`.
@@ -593,11 +593,21 @@ export class Job extends Construct implements SSTConstruct {
       const code = AssetCode.fromAsset(result.out);
       const codeConfig = code.bind(this);
       const project = this.job.node.defaultChild as CfnProject;
+      const images = {
+        arm_64: {
+          "nodejs16.x": "amazon/aws-lambda-nodejs:16.2023.07.13.14",
+          "nodejs18.x": "amazon/aws-lambda-nodejs:18.2023.12.14.13",
+          "nodejs20.x": "amazon/aws-lambda-nodejs:20.2023.12.14.13"
+        },
+        x86_64: {
+          "nodejs18.x": "amazon/aws-lambda-nodejs:18",
+          "nodejs16.x": "amazon/aws-lambda-nodejs:16",
+          "nodejs20.x": "amazon/aws-lambda-nodejs:20"
+        }
+      }
       const image = LinuxBuildImage.fromDockerRegistry(
         // ARM images can be found here https://hub.docker.com/r/amazon/aws-lambda-nodejs
-        architecture === "arm_64"
-          ? "amazon/aws-lambda-nodejs:18.2023.12.14.13"
-          : "amazon/aws-lambda-nodejs:18"
+        images[architecture || "x86_64"][runtime || "nodejs18.x"]
       );
       project.environment = {
         ...project.environment,

--- a/packages/sst/src/constructs/Job.ts
+++ b/packages/sst/src/constructs/Job.ts
@@ -99,7 +99,7 @@ export interface JobProps {
   architecture?: "x86_64" | "arm_64";
   /**
    * The runtime environment for the job.
-   * @default "nodejs"
+   * @default "nodejs18.x"
    * @example
    * ```js
    * new Job(stack, "MyJob", {
@@ -108,7 +108,7 @@ export interface JobProps {
    * })
    *```
    */
-  runtime?: "nodejs16.x" | "nodejs18.x" | "nodejs20.x" | "container";
+  runtime?: "nodejs" | "nodejs16.x" | "nodejs18.x" | "nodejs20.x" | "container";
   /**
    * For "nodejs" runtime, point to the entry point and handler function.
    * Of the format: `/path/to/file.function`.
@@ -595,19 +595,21 @@ export class Job extends Construct implements SSTConstruct {
       const project = this.job.node.defaultChild as CfnProject;
       const dockerImageMap = {
         arm_64: {
+          nodejs: "amazon/aws-lambda-nodejs:16.2023.07.13.14",
           "nodejs16.x": "amazon/aws-lambda-nodejs:16.2023.07.13.14",
           "nodejs18.x": "amazon/aws-lambda-nodejs:18.2023.12.14.13",
-          "nodejs20.x": "amazon/aws-lambda-nodejs:20.2023.12.14.13"
+          "nodejs20.x": "amazon/aws-lambda-nodejs:20.2023.12.14.13",
         },
         x86_64: {
+          nodejs: "amazon/aws-lambda-nodejs:16",
           "nodejs16.x": "amazon/aws-lambda-nodejs:16",
           "nodejs18.x": "amazon/aws-lambda-nodejs:18",
-          "nodejs20.x": "amazon/aws-lambda-nodejs:20"
-        }
-      }
+          "nodejs20.x": "amazon/aws-lambda-nodejs:20",
+        },
+      };
       const image = LinuxBuildImage.fromDockerRegistry(
         // ARM images can be found here https://hub.docker.com/r/amazon/aws-lambda-nodejs
-        dockerImageMap[architecture || "x86_64"][runtime || "nodejs18.x"]
+        dockerImageMap[architecture ?? "x86_64"][runtime ?? "nodejs18.x"]
       );
       project.environment = {
         ...project.environment,

--- a/packages/sst/src/constructs/Job.ts
+++ b/packages/sst/src/constructs/Job.ts
@@ -593,21 +593,21 @@ export class Job extends Construct implements SSTConstruct {
       const code = AssetCode.fromAsset(result.out);
       const codeConfig = code.bind(this);
       const project = this.job.node.defaultChild as CfnProject;
-      const images = {
+      const dockerImageMap = {
         arm_64: {
           "nodejs16.x": "amazon/aws-lambda-nodejs:16.2023.07.13.14",
           "nodejs18.x": "amazon/aws-lambda-nodejs:18.2023.12.14.13",
           "nodejs20.x": "amazon/aws-lambda-nodejs:20.2023.12.14.13"
         },
         x86_64: {
-          "nodejs18.x": "amazon/aws-lambda-nodejs:18",
           "nodejs16.x": "amazon/aws-lambda-nodejs:16",
+          "nodejs18.x": "amazon/aws-lambda-nodejs:18",
           "nodejs20.x": "amazon/aws-lambda-nodejs:20"
         }
       }
       const image = LinuxBuildImage.fromDockerRegistry(
         // ARM images can be found here https://hub.docker.com/r/amazon/aws-lambda-nodejs
-        images[architecture || "x86_64"][runtime || "nodejs18.x"]
+        dockerImageMap[architecture || "x86_64"][runtime || "nodejs18.x"]
       );
       project.environment = {
         ...project.environment,


### PR DESCRIPTION
This PR updates the docker images used for jobs, I searched the latest available ARM image with nodejs 18 and 20. 
this PR sets the new default as nodejs18 but I could revert it back to nodejs 16 if necessary so as not to create a potentially breaking change