### PR TITLE
docs: add note about client Config import location

### DIFF
--- a/www/docs/config.md
+++ b/www/docs/config.md
@@ -108,6 +108,10 @@ We use the [`sst secrets`](packages/sst.md#sst-secrets) CLI.
 
 Now you can access the secret and parameter in your Next.js app.
 
+:::tip
+Note that the Config client import is not from sst/construct
+:::
+
 ```ts title="packages/web/pages/index.tsx" {1,4}
 import { Config } from "sst/node/config";
 

--- a/www/docs/config.md
+++ b/www/docs/config.md
@@ -108,9 +108,6 @@ We use the [`sst secrets`](packages/sst.md#sst-secrets) CLI.
 
 Now you can access the secret and parameter in your Next.js app.
 
-:::tip
-Note that the Config client import is not from sst/construct
-:::
 
 ```ts title="packages/web/pages/index.tsx" {1,4}
 import { Config } from "sst/node/config";
@@ -123,7 +120,7 @@ export async function getServerSideProps() {
 ```
 
 :::tip
-Since we are dealing with sensitive info, Config is only supported in the frontend's server side functions.
+The Config client is imported from `sst/node/config`, not `sst/constructs`.
 :::
 
 ---


### PR DESCRIPTION
Hey I had the issue described here

https://github.com/sst/sst/issues/2904

and 

https://discord.com/channels/983865673656705025/1116777988600631457

My issue was that the `{ Config } from "sst/constructs"` is used to set Config but the `{ Config } from "sst/node/config"` is used to read the values. 

It's correct in the docs examples but easy to miss (for me anyway hah) and might be worth explicitly calling out that they are the same named export but from different locations.

This just adds a tip there.