### PR TITLE
fix: Converting layer example from nodejs.install to nodejs.esbuild.external

### DIFF
--- a/www/docs/advanced/lambda-layers.md
+++ b/www/docs/advanced/lambda-layers.md
@@ -39,7 +39,9 @@ Say you wanted to use the [sharp package](https://www.npmjs.com/package/sharp) i
    new sst.Function(stack, "Function", {
      handler: "src/lambda.main",
      nodejs: {
-       install: ["sharp"],
+       esbuild: {
+        external: ["sharp"],
+       },
      },
      layers: [
        new lambda.LayerVersion(stack, "MyLayer", {
@@ -77,7 +79,9 @@ Say you wanted to use the [chrome-aws-lambda-layer](https://github.com/shelfio/c
    new sst.Function(stack, "Function", {
      handler: "src/lambda.main",
      nodejs: {
-       install: ["chrome-aws-lambda"],
+       esbuild: {
+        external: ["chrome-aws-lambda"],
+       },
      },
      layers: [
        lambda.LayerVersion.fromLayerVersionArn(stack, "ChromeLayer", layerArn),


### PR DESCRIPTION
The current example for using sharp and chrome layers uses the install option of the Function construct

This causes the function to install the package, which is not correct as we're looking to mark the function as external and use the code from the layers.

This PR converts from using nodejs.install in the function config to nodejs.esbuild.external