### PR TITLE
feat: Add client address for Astro

### DIFF
--- a/.changeset/serious-apricots-wonder.md
+++ b/.changeset/serious-apricots-wonder.md
@@ -1,0 +1,5 @@
+---
+"astro-sst": patch
+---
+
+Astro: add client address property

--- a/packages/astro-sst/package.json
+++ b/packages/astro-sst/package.json
@@ -56,6 +56,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.130",
     "@types/set-cookie-parser": "^2.4.7",
-    "astro": "^4.0.2"
+    "astro": "^4.2.6"
   }
 }


### PR DESCRIPTION
Newer versions of `astro` (`<= 4.2.0`) support including the `clientAddress` as a property of the `RenderOptions` argument for the render method. This PR grabs the `x-forwarded-for` header and uses it for the `clientAddress` with a fallback to the `remoteAddress` value (which is likely an AWS resource, not the actual user).

Resolves #2918

Astro changes that enabled the functionality: https://github.com/withastro/astro/commit/d6edc7540864cf5d294d7b881eb886a3804f6d05