### PR TITLE
[future/auth] use query params on success too

### DIFF
--- a/packages/sst/src/node/future/auth/handler.ts
+++ b/packages/sst/src/node/future/auth/handler.ts
@@ -485,7 +485,10 @@ export function AuthHandler<
               }
             );
 
-          const { client_id, state } = useCookies();
+          const { client_id, state } = {
+            ...useCookies(),
+            ...useQueryParams(),
+          } as Record<string, string>;
 
           if (response_type === "token") {
             const location = new URL(redirect_uri);


### PR DESCRIPTION
bringing back this behavior from v2.24.22
https://github.com/sst/sst/blob/766436883ee7b7b23637cf9d3effd08a07b861fe/packages/sst/src/node/future/auth/handler.ts#L300 so `state` query param is also copied from query params on success step too.

the regression observed is that `?state=` is empty when doing the final redirect after success (at least tested with google adapter) as `state` arrives as a query param to the auth handler.

link to discord with more details: https://discord.com/channels/983865673656705025/1082462837710012508/1203065839591489566