### PR TITLE
docs: fix typos in frontend construct examples

### DIFF
--- a/www/docs/constructs/NextjsSite.about.md
+++ b/www/docs/constructs/NextjsSite.about.md
@@ -28,7 +28,7 @@ Here's how it works at a high level.
 2. This adds the `NextjsSite` construct to your stacks code.
 
    ```ts {8-10}
-   import { NextjsSite, StackContext } as sst from "sst/constructs";
+   import { NextjsSite, StackContext } from "sst/constructs";
 
    export default function MyStack({ stack }: StackContext) {
 

--- a/www/docs/constructs/RemixSite.about.md
+++ b/www/docs/constructs/RemixSite.about.md
@@ -75,7 +75,7 @@ The `RemixSite` construct is a higher level CDK construct that makes it easy to 
 4. Add the `RemixSite` construct to an existing stack in your SST app. You can also create a new stack for the app.
 
    ```ts
-   import { RemixSite, StackContext } as sst from "sst/constructs";
+   import { RemixSite, StackContext } from "sst/constructs";
 
    export default function MyStack({ stack }: StackContext) {
 

--- a/www/docs/constructs/SolidStartSite.about.md
+++ b/www/docs/constructs/SolidStartSite.about.md
@@ -90,7 +90,7 @@ The `SolidStartSite` construct is a higher level CDK construct that makes it eas
 5. Add the `SolidStartSite` construct to an existing stack in your SST app. You can also create a new stack for the app.
 
    ```ts
-   import { SolidStartSite, StackContext } as sst from "sst/constructs";
+   import { SolidStartSite, StackContext } from "sst/constructs";
 
    export default function MyStack({ stack }: StackContext) {
 

--- a/www/docs/constructs/v1/RemixSite.about.md
+++ b/www/docs/constructs/v1/RemixSite.about.md
@@ -84,7 +84,7 @@ Update the package.json scripts for your Remix application.
 4. Add the `RemixSite` construct to an existing stack in your SST app. You can also create a new stack for the app.
 
 ```ts
-import { RemixSite, StackContext } as sst from "@serverless-stack/resources";
+import { RemixSite, StackContext } from "@serverless-stack/resources";
 
 export default function MyStack({ stack }: StackContext) {
 


### PR DESCRIPTION
Fixes some typos in the import statements of some frontend construct examples. They are as follows:

- Named import statement error on [NextjsSite quickstart](https://docs.sst.dev/constructs/NextjsSite#quick-start) step
- Named import statement error on [RemixSite quickstart](https://docs.sst.dev/constructs/NextjsSite#quick-start) step 4
- Named import statement error on [SolidStartSite quickstart](https://docs.sst.dev/constructs/NextjsSite#quick-start) step 5
- Named import statement error on [RemixSite quickstart v1](https://docs.sst.dev/constructs/v1/RemixSite#quick-start) step 4

An example:

`import { NextjsSite, StackContext } as sst from "sst/constructs";`

where as sst is incorrect.