### PR TITLE
Runtime: Fix rust local-lambda build step on windows #

### DIFF
--- a/.changeset/fuzzy-apes-fetch.md
+++ b/.changeset/fuzzy-apes-fetch.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Runtime: Fix rust local-lambda build step on windows #

--- a/packages/sst/src/runtime/handlers/rust.ts
+++ b/packages/sst/src/runtime/handlers/rust.ts
@@ -11,7 +11,8 @@ const execAsync = promisify(exec);
 export const useRustHandler = (): RuntimeHandler => {
   const processes = new Map<string, ChildProcessWithoutNullStreams>();
   const sources = new Map<string, string>();
-  const handlerName = process.platform === "win32" ? `handler.exe` : `handler`;
+  const isWindows = process.platform === "win32";
+  const handlerName = isWindows ? `handler.exe` : `handler`;
 
   return {
     shouldBuild: (input) => {
@@ -74,7 +75,7 @@ export const useRustHandler = (): RuntimeHandler => {
             }
           );
           await fs.cp(
-            path.join(project, `target/debug`, parsed.name),
+            path.join(project, `target/debug`, `${parsed.name}${isWindows ? ".exe" : ""}`),
             path.join(input.out, "handler")
           );
         } catch (ex) {


### PR DESCRIPTION
When compiling rust lambda functions on Windows platform, there is bug when sst runtime handler for rust is trying to copy files into the artifacts folder.

Running cargo build on windows creates files with .exe extension.
![image](https://github.com/sst/sst/assets/26041819/c2693a86-ccc0-4bc4-94aa-3b47a5ec65ec)

Copying files into artifacts folder then failes because it cant find "main" file.

In deploy mode, there is no need to add ".exe" extension to "bootstrap" file since cargo lambda build is set up correctly to build with linux environment.

[Discord thread](https://discord.com/channels/983865673656705025/1202981470160035850)