### PR TITLE
Docs: Fix the cron job rate to be once a day

### DIFF
--- a/.changeset/fifty-rockets-protect.md
+++ b/.changeset/fifty-rockets-protect.md
@@ -1,0 +1,5 @@
+---
+"@sst/docs": patch
+---
+
+Fixes cron schedule for remix starter guide

--- a/www/docs/start/remix.md
+++ b/www/docs/start/remix.md
@@ -233,7 +233,7 @@ Next, we'll add a cron job to remove the uploaded files every day. Add this to `
 
 ```ts title="sst.config.ts"
 new Cron(stack, "cron", {
-  schedule: "rate(1 minute)",
+  schedule: "rate(1 day)",
   job: {
     function: {
       bind: [bucket],


### PR DESCRIPTION
The remix starter example includes a cron job to delete uploaded files once per day, but the schedule was set to once per minute. This commits fixes the cron rate to be once per day to match the rest of the documentation.