### PR TITLE
Fix runtime for container function

### DIFF
--- a/.changeset/strange-rabbits-joke.md
+++ b/.changeset/strange-rabbits-joke.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Fix runtime for container function

--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -978,7 +978,7 @@ export class Function extends CDKFunction implements SSTConstruct {
           ? {
               code: Code.fromInline("export function placeholder() {}"),
               handler: "index.placeholder",
-              runtime: CDKRuntime.NODEJS_18_X,
+              runtime: CDKRuntime.FROM_IMAGE,
               layers: undefined,
             }
           : {


### PR DESCRIPTION
Runtime for container function seems to have changed to NodeJS 
https://github.com/sst/sst/commit/ecba06be80e99a8b064cf65718b6a188537e640e

So we have a piece of code that check function runtime to skip certain behaviour for Datadog integration that would break(e.g: https://github.com/DataDog/datadog-cdk-constructs/blob/754dca272494089b0b3a018ad62e0c8a9c9debfb/v2/src/redirect.ts#L30).

