### PR TITLE
Fix: Await All Functions Builds During file.change event

### DIFF
--- a/packages/sst/src/runtime/handlers.ts
+++ b/packages/sst/src/runtime/handlers.ts
@@ -214,19 +214,18 @@ export const useFunctionBuilder = lazy(() => {
   watcher.subscribe("file.changed", async (evt) => {
     try {
       const functions = useFunctions();
-      for (const [functionID, info] of Object.entries(functions.all)) {
-        const handler = handlers.for(info.runtime!);
-        if (
-          !handler?.shouldBuild({
-            functionID,
-            file: evt.properties.file,
-          })
-        )
-          continue;
+      await Promise.all(Object.entries(functions.all).map(async ([functionID, info]) => {
+        const handler = handlers.for(info.runtime);
+        if (!handler?.shouldBuild({
+          functionID,
+          file: evt.properties.file,
+        }))
+          return;
         await result.build(functionID);
-        Logger.debug("Rebuilt function", functionID);
-      }
-    } catch {}
+        console.log("Rebuilt function", functionID);
+      }));
+    }
+    catch { }
   });
 
   return result;


### PR DESCRIPTION
This fixes lambda functions updates when 1 file change effects multiple lambdas.  More details here: https://discord.com/channels/983865673656705025/1207750476213256222 