### PR TITLE
Update Service construct to be able to create an http -> https listener on the load balancer itself.

### DIFF
--- a/packages/sst/src/constructs/Service.ts
+++ b/packages/sst/src/constructs/Service.ts
@@ -561,11 +561,11 @@ type HttpsListenerProps = {
    * @example
    * ```js
    * {
-   *   https: true,
+   *   httpsRedirect: true,
    * }
    * ```
    */
-  https?: boolean;
+  httpsRedirect?: boolean;
   /**
    * This option attaches these certificate to the https load balancer. This must be specified
    * @default undefined
@@ -1006,7 +1006,7 @@ export class Service extends Construct implements SSTConstruct {
     let target: ApplicationTargetGroup;
 
     const albConfig = cdk?.applicationLoadBalancer as AlbProps;
-    if (albConfig.https) {
+    if (albConfig.httpsRedirect) {
       if (!albConfig.certificates) {
         throw new VisibleError(
             `In the "${this.node.id}" Service, the "httpsLoadBalancer" option is enabled but no "certificates" are provided.`

--- a/packages/sst/src/constructs/Service.ts
+++ b/packages/sst/src/constructs/Service.ts
@@ -69,7 +69,8 @@ import {
   ApplicationTargetGroupProps,
   ApplicationProtocol,
   CfnListener,
-  ListenerAction, IListenerCertificate
+  ListenerAction,
+  IListenerCertificate,
 } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { createAppContext } from "./context.js";
 import { toCdkSize } from "./index.js";
@@ -180,7 +181,7 @@ const supportedMemories = {
 
 export interface ServiceDomainProps extends DistributionDomainProps {}
 export interface ServiceCdkDistributionProps
-    extends Omit<DistributionProps, "defaultBehavior"> {}
+  extends Omit<DistributionProps, "defaultBehavior"> {}
 
 export interface ServiceProps {
   /**
@@ -214,7 +215,7 @@ export interface ServiceProps {
    * ```
    */
   architecture?: Lowercase<
-      keyof Pick<typeof CpuArchitecture, "ARM64" | "X86_64">
+    keyof Pick<typeof CpuArchitecture, "ARM64" | "X86_64">
   >;
   /**
    * The amount of CPU allocated.
@@ -472,9 +473,7 @@ export interface ServiceProps {
      * }
      * ```
      */
-    applicationLoadBalancer?:
-        | boolean
-        | AlbProps;
+    applicationLoadBalancer?: boolean | AlbProps;
     /**
      * Customize the Application Load Balancer's target group.
      * @default true
@@ -577,7 +576,7 @@ type HttpsListenerProps = {
    * ```
    */
   certificates?: IListenerCertificate[];
-}
+};
 /**
  * The `Service` construct is a higher level CDK construct that makes it easy to create modern web apps with Server Side Rendering capabilities.
  * @example
@@ -617,7 +616,7 @@ export class Service extends Construct implements SSTConstruct {
       ...props,
     };
     this.doNotDeploy =
-        !stack.isActive || (app.mode === "dev" && !this.props.dev?.deploy);
+      !stack.isActive || (app.mode === "dev" && !this.props.dev?.deploy);
 
     this.validateServiceExists();
     this.validateMemoryCpuAndStorage();
@@ -633,7 +632,7 @@ export class Service extends Construct implements SSTConstruct {
     // Create ECS cluster
     const vpc = this.createVpc();
     const { cluster, container, taskDefinition, service } =
-        this.createService(vpc);
+      this.createService(vpc);
     const { alb, target } = this.createLoadBalancer(vpc, service);
     this.createAutoScaling(service, target);
     this.alb = alb;
@@ -649,13 +648,13 @@ export class Service extends Construct implements SSTConstruct {
     this.bindForService(props?.bind || []);
     this.attachPermissionsForService(props?.permissions || []);
     Object.entries(props?.environment || {}).map(([key, value]) =>
-        this.addEnvironmentForService(key, value)
+      this.addEnvironmentForService(key, value)
     );
 
     useDeferredTasks().add(async () => {
       if (!app.isRunningSSTTest() && !props?.cdk?.container?.image) {
         Colors.line(
-            `➜  Building the container image for the "${this.node.id}" service...`
+          `➜  Building the container image for the "${this.node.id}" service...`
         );
 
         // Build app
@@ -736,8 +735,8 @@ export class Service extends Construct implements SSTConstruct {
       type: "Service" as const,
       data: {
         mode: this.doNotDeploy
-            ? ("placeholder" as const)
-            : ("deployed" as const),
+          ? ("placeholder" as const)
+          : ("deployed" as const),
         path: this.props.path,
         customDomainUrl: this.customDomainUrl,
         url: this.url,
@@ -745,8 +744,8 @@ export class Service extends Construct implements SSTConstruct {
         task: this.taskDefinition?.taskDefinitionArn,
         container: this.container?.containerName,
         secrets: (this.props.bind || [])
-            .filter((c) => c instanceof Secret)
-            .map((c) => (c as Secret).name),
+          .filter((c) => c instanceof Secret)
+          .map((c) => (c as Secret).name),
       },
     };
   }
@@ -755,15 +754,15 @@ export class Service extends Construct implements SSTConstruct {
   public getFunctionBinding(): FunctionBindingProps {
     const app = this.node.root as App;
     return this.distribution
-        ? {
+      ? {
           clientPackage: "service",
           variables: {
             url: this.doNotDeploy
-                ? {
+              ? {
                   type: "plain",
                   value: this.props.dev?.url ?? "localhost",
                 }
-                : {
+              : {
                   // Do not set real value b/c we don't want to make the Lambda function
                   // depend on the Site. B/c often the site depends on the Api, causing
                   // a CloudFormation circular dependency if the Api and the Site belong
@@ -775,12 +774,12 @@ export class Service extends Construct implements SSTConstruct {
           permissions: {
             "ssm:GetParameters": [
               `arn:${Stack.of(this).partition}:ssm:${app.region}:${
-                  app.account
+                app.account
               }:parameter${getParameterPath(this, "url")}`,
             ],
           },
         }
-        : {
+      : {
           clientPackage: "service",
           variables: {},
           permissions: {},
@@ -839,26 +838,26 @@ export class Service extends Construct implements SSTConstruct {
     // Validate path exists
     if (!fs.existsSync(servicePath)) {
       throw new VisibleError(
-          `In the "${this.node.id}" Service, path is not found at "${path.resolve(
-              servicePath
-          )}"`
+        `In the "${this.node.id}" Service, path is not found at "${path.resolve(
+          servicePath
+        )}"`
       );
     }
 
     // Validate path is a directory
     if (fs.statSync(servicePath).isFile()) {
       throw new VisibleError(
-          [
-            `In the "${this.node.id}" Service, the path "${path.resolve(
-                servicePath
-            )}" should be a directory.`,
-            `Did you mean:`,
-            ``,
-            `  {`,
-            `    path: "${path.dirname(servicePath)}",`,
-            `    file: "${path.basename(servicePath)}",`,
-            `  }`,
-          ].join("\n")
+        [
+          `In the "${this.node.id}" Service, the path "${path.resolve(
+            servicePath
+          )}" should be a directory.`,
+          `Did you mean:`,
+          ``,
+          `  {`,
+          `    path: "${path.dirname(servicePath)}",`,
+          `    file: "${path.basename(servicePath)}",`,
+          `  }`,
+        ].join("\n")
       );
     }
 
@@ -867,7 +866,7 @@ export class Service extends Construct implements SSTConstruct {
       const dockerfilePath = path.join(servicePath, file);
       if (!fs.existsSync(dockerfilePath)) {
         throw new VisibleError(
-            `In the "${this.node.id}" Service, no Dockerfile is found at "${dockerfilePath}". Make sure to set the "file" property to the path of the Dockerfile relative to "${servicePath}".`
+          `In the "${this.node.id}" Service, no Dockerfile is found at "${dockerfilePath}". Make sure to set the "file" property to the path of the Dockerfile relative to "${servicePath}".`
         );
       }
     }
@@ -877,29 +876,29 @@ export class Service extends Construct implements SSTConstruct {
     const { memory, cpu, storage } = this.props;
     if (!supportedCpus[cpu]) {
       throw new VisibleError(
-          `In the "${
-              this.node.id
-          }" Service, only the following "cpu" settings are supported: ${Object.keys(
-              supportedCpus
-          ).join(", ")}`
+        `In the "${
+          this.node.id
+        }" Service, only the following "cpu" settings are supported: ${Object.keys(
+          supportedCpus
+        ).join(", ")}`
       );
     }
 
     // @ts-ignore
     if (!supportedMemories[cpu][memory]) {
       throw new VisibleError(
-          `In the "${
-              this.node.id
-          }" Service, only the following "memory" settings are supported with "${cpu}": ${Object.keys(
-              supportedMemories[cpu]
-          ).join(", ")}`
+        `In the "${
+          this.node.id
+        }" Service, only the following "memory" settings are supported with "${cpu}": ${Object.keys(
+          supportedMemories[cpu]
+        ).join(", ")}`
       );
     }
 
     const storageInGiB = toCdkSize(storage).toGibibytes();
     if (storageInGiB < 20 || storageInGiB > 200) {
       throw new VisibleError(
-          `In the "${this.node.id}" Service, the supported value for storage is between "20 GB" and "200 GB"`
+        `In the "${this.node.id}" Service, the supported value for storage is between "20 GB" and "200 GB"`
       );
     }
   }
@@ -908,23 +907,23 @@ export class Service extends Construct implements SSTConstruct {
     const { cdk } = this.props;
 
     return (
-        cdk?.vpc ??
-        new Vpc(this, "Vpc", {
-          natGateways: 1,
-        })
+      cdk?.vpc ??
+      new Vpc(this, "Vpc", {
+        natGateways: 1,
+      })
     );
   }
 
   private createService(vpc: IVpc) {
     const { architecture, cpu, memory, storage, port, logRetention, cdk } =
-        this.props;
+      this.props;
     const app = this.node.root as App;
     const clusterName = app.logicalPrefixedName(this.node.id);
 
     const logGroup = new LogRetention(this, "LogRetention", {
       logGroupName: `/sst/service/${clusterName}`,
       retention:
-          RetentionDays[logRetention.toUpperCase() as keyof typeof RetentionDays],
+        RetentionDays[logRetention.toUpperCase() as keyof typeof RetentionDays],
       logRetentionRetryOptions: {
         maxRetries: 100,
       },
@@ -943,21 +942,21 @@ export class Service extends Construct implements SSTConstruct {
       // note: the minimum allowed value by CloudFormation is 21, set to
       //       undefined to set to the default value of 20
       ephemeralStorageGiB:
-          ephemeralStorageGiB === 20 ? undefined : ephemeralStorageGiB,
+        ephemeralStorageGiB === 20 ? undefined : ephemeralStorageGiB,
       runtimePlatform: {
         cpuArchitecture:
-            architecture === "arm64"
-                ? CpuArchitecture.ARM64
-                : CpuArchitecture.X86_64,
+          architecture === "arm64"
+            ? CpuArchitecture.ARM64
+            : CpuArchitecture.X86_64,
       },
     });
 
     const container = taskDefinition.addContainer("Container", {
       logging: new AwsLogDriver({
         logGroup: LogGroup.fromLogGroupArn(
-            this,
-            "LogGroup",
-            logGroup.logGroupArn
+          this,
+          "LogGroup",
+          logGroup.logGroupArn
         ),
         streamPrefix: "service",
       }),
@@ -989,7 +988,7 @@ export class Service extends Construct implements SSTConstruct {
     if (cdk?.applicationLoadBalancer === false) {
       if (cdk?.applicationLoadBalancerTargetGroup)
         throw new VisibleError(
-            `In the "${this.node.id}" Service, the "cdk.applicationLoadBalancerTargetGroup" cannot be applied if the Application Load Balancer is disabled.`
+          `In the "${this.node.id}" Service, the "cdk.applicationLoadBalancerTargetGroup" cannot be applied if the Application Load Balancer is disabled.`
         );
       return {};
     }
@@ -998,8 +997,8 @@ export class Service extends Construct implements SSTConstruct {
       vpc,
       internetFacing: true,
       ...(cdk?.applicationLoadBalancer === true
-          ? {}
-          : cdk?.applicationLoadBalancer),
+        ? {}
+        : cdk?.applicationLoadBalancer),
     });
 
     let listener: ApplicationListener;
@@ -1009,31 +1008,33 @@ export class Service extends Construct implements SSTConstruct {
     if (albConfig.httpsRedirect) {
       if (!albConfig.certificates) {
         throw new VisibleError(
-            `In the "${this.node.id}" Service, the "httpsLoadBalancer" option is enabled but no "certificates" are provided.`
+          `In the "${this.node.id}" Service, the "httpsLoadBalancer" option is enabled but no "certificates" are provided.`
         );
       }
-      let httpListener = alb.addListener('HttpListener', {
+      let httpListener = alb.addListener("HttpListener", {
         protocol: ApplicationProtocol.HTTP,
-      })
+      });
       // Dummy response. If omitted, we get the following error on `cdk synth`:
       // "Listener needs at least one default target group (call addTargetGroups)"
       // See: https://github.com/aws/aws-cdk/issues/2563 for details
       httpListener.addAction("DummyResponse", {
-        action: ListenerAction.fixedResponse(404)
+        action: ListenerAction.fixedResponse(404),
       });
       const cfnHttpListener = httpListener.node.defaultChild as CfnListener;
-      cfnHttpListener.defaultActions = [{
-        type: "redirect",
-        redirectConfig: {
-          protocol: "HTTPS",
-          host: "#{host}",
-          path: "/#{path}",
-          query: "#{query}",
-          port: "443",
-          statusCode: "HTTP_301"
-        }
-      }];
-      listener = alb.addListener('HttpsListener', {
+      cfnHttpListener.defaultActions = [
+        {
+          type: "redirect",
+          redirectConfig: {
+            protocol: "HTTPS",
+            host: "#{host}",
+            path: "/#{path}",
+            query: "#{query}",
+            port: "443",
+            statusCode: "HTTP_301",
+          },
+        },
+      ];
+      listener = alb.addListener("HttpsListener", {
         protocol: ApplicationProtocol.HTTPS,
         port: 443,
         certificates: albConfig.certificates,
@@ -1042,7 +1043,7 @@ export class Service extends Construct implements SSTConstruct {
         port: 80,
         targets: [service],
         ...cdk?.applicationLoadBalancerTargetGroup,
-      })
+      });
     } else {
       listener = alb.addListener("Listener", { port: 80 });
       target = listener.addTargets("TargetGroup", {
@@ -1056,8 +1057,8 @@ export class Service extends Construct implements SSTConstruct {
   }
 
   private createAutoScaling(
-      service: FargateService,
-      target?: ApplicationTargetGroup
+    service: FargateService,
+    target?: ApplicationTargetGroup
   ) {
     const {
       minContainers,
@@ -1123,8 +1124,8 @@ export class Service extends Construct implements SSTConstruct {
             originRequestPolicy: OriginRequestPolicy.ALL_VIEWER,
           },
           ...(cdk?.cloudfrontDistribution === true
-              ? {}
-              : cdk?.cloudfrontDistribution),
+            ? {}
+            : cdk?.cloudfrontDistribution),
         },
       },
     });
@@ -1136,8 +1137,8 @@ export class Service extends Construct implements SSTConstruct {
     const app = this.node.root as App;
     const role = new Role(this, "ServerFunctionRole", {
       assumedBy: new CompositePrincipal(
-          new AccountPrincipal(app.account),
-          new ServicePrincipal("lambda.amazonaws.com")
+        new AccountPrincipal(app.account),
+        new ServicePrincipal("lambda.amazonaws.com")
       ),
       maxSessionDuration: CdkDuration.hours(12),
     });
@@ -1145,9 +1146,9 @@ export class Service extends Construct implements SSTConstruct {
     return new Function(this, `ServerFunction`, {
       description: "Service dev function",
       handler: path.join(
-          __dirname,
-          "../support/service-dev-function",
-          "index.handler"
+        __dirname,
+        "../support/service-dev-function",
+        "index.handler"
       ),
       runtime: "nodejs18.x",
       memorySize: "512 MB",
@@ -1164,26 +1165,26 @@ export class Service extends Construct implements SSTConstruct {
     // Get referenced secrets
     const referencedSecrets: Secret[] = [];
     constructs.forEach((c) =>
-        referencedSecrets.push(...getReferencedSecrets(c))
+      referencedSecrets.push(...getReferencedSecrets(c))
     );
 
     [...constructs, ...referencedSecrets].forEach((c) => {
       // Bind environment
       const env = bindEnvironment(c);
       Object.entries(env).forEach(([key, value]) =>
-          this.addEnvironmentForService(key, value)
+        this.addEnvironmentForService(key, value)
       );
 
       // Bind permissions
       const permissions = bindPermissions(c);
       Object.entries(permissions).forEach(([action, resources]) =>
-          this.attachPermissionsForService([
-            new PolicyStatement({
-              actions: [action],
-              effect: Effect.ALLOW,
-              resources,
-            }),
-          ])
+        this.attachPermissionsForService([
+          new PolicyStatement({
+            actions: [action],
+            effect: Effect.ALLOW,
+            resources,
+          }),
+        ])
       );
     });
   }
@@ -1204,23 +1205,23 @@ export class Service extends Construct implements SSTConstruct {
   private async createNixpacksBuilder() {
     try {
       await execAsync(
-          [
-            "docker",
-            "build",
-            `-t ${NIXPACKS_IMAGE_NAME}`,
-            "--platform=linux/amd64",
-            path.resolve(__dirname, "../support/nixpacks"),
-          ].join(" "),
-          {
-            env: {
-              ...process.env,
-            },
-          }
+        [
+          "docker",
+          "build",
+          `-t ${NIXPACKS_IMAGE_NAME}`,
+          "--platform=linux/amd64",
+          path.resolve(__dirname, "../support/nixpacks"),
+        ].join(" "),
+        {
+          env: {
+            ...process.env,
+          },
+        }
       );
     } catch (e) {
       console.error(e);
       throw new VisibleError(
-          `Failed to setup Nixpacks builder for the ${this.node.id} service`
+        `Failed to setup Nixpacks builder for the ${this.node.id} service`
       );
     }
   }
@@ -1229,27 +1230,27 @@ export class Service extends Construct implements SSTConstruct {
     const { path: servicePath } = this.props;
     try {
       await execAsync(
-          [
-            "docker",
-            "run",
-            "--rm",
-            "--network=host",
-            `--name=sst-${this.node.id}-service`,
-            `-v=${path.resolve(servicePath)}:/service`,
-            `-w="/service"`,
-            NIXPACKS_IMAGE_NAME,
-            `build . --out .`,
-          ].join(" "),
-          {
-            env: {
-              ...process.env,
-            },
-          }
+        [
+          "docker",
+          "run",
+          "--rm",
+          "--network=host",
+          `--name=sst-${this.node.id}-service`,
+          `-v=${path.resolve(servicePath)}:/service`,
+          `-w="/service"`,
+          NIXPACKS_IMAGE_NAME,
+          `build . --out .`,
+        ].join(" "),
+        {
+          env: {
+            ...process.env,
+          },
+        }
       );
     } catch (e) {
       console.error(e);
       throw new VisibleError(
-          `Failed to run Nixpacks build for the ${this.node.id} service`
+        `Failed to run Nixpacks build for the ${this.node.id} service`
       );
     }
     return ".nixpacks/Dockerfile";
@@ -1260,22 +1261,22 @@ export class Service extends Construct implements SSTConstruct {
     const platform = architecture === "arm64" ? "linux/arm64" : "linux/amd64";
     try {
       await execAsync(
-          [
-            "docker",
-            "build",
-            `-t sst-build:service-${this.node.id}`,
-            `--platform ${platform}`,
-            `-f ${path.join(servicePath, dockerfile)}`,
-            ...Object.entries(build?.buildArgs || {}).map(
-                ([k, v]) => `--build-arg ${k}=${v}`
-            ),
-            this.props.path,
-          ].join(" "),
-          {
-            env: {
-              ...process.env,
-            },
-          }
+        [
+          "docker",
+          "build",
+          `-t sst-build:service-${this.node.id}`,
+          `--platform ${platform}`,
+          `-f ${path.join(servicePath, dockerfile)}`,
+          ...Object.entries(build?.buildArgs || {}).map(
+            ([k, v]) => `--build-arg ${k}=${v}`
+          ),
+          this.props.path,
+        ].join(" "),
+        {
+          env: {
+            ...process.env,
+          },
+        }
       );
     } catch (e) {
       console.error(e);
@@ -1284,14 +1285,14 @@ export class Service extends Construct implements SSTConstruct {
   }
 
   private updateContainerImage(
-      dockerfile: string,
-      taskDefinition: FargateTaskDefinition,
-      container: ContainerDefinition
+    dockerfile: string,
+    taskDefinition: FargateTaskDefinition,
+    container: ContainerDefinition
   ) {
     const { path: servicePath, architecture, build } = this.props;
     const image = ContainerImage.fromAsset(servicePath, {
       platform:
-          architecture === "arm64" ? Platform.LINUX_ARM64 : Platform.LINUX_AMD64,
+        architecture === "arm64" ? Platform.LINUX_ARM64 : Platform.LINUX_AMD64,
       file: dockerfile,
       buildArgs: build?.buildArgs,
       exclude: [".sst/dist", ".sst/artifacts"],
@@ -1299,8 +1300,8 @@ export class Service extends Construct implements SSTConstruct {
     });
     const cfnTask = taskDefinition.node.defaultChild as CfnTaskDefinition;
     cfnTask.addPropertyOverride(
-        "ContainerDefinitions.0.Image",
-        image.bind(this, container).imageName
+      "ContainerDefinitions.0.Image",
+      image.bind(this, container).imageName
     );
   }
 }


### PR DESCRIPTION
Internally, my team needs to be able to create a load balancer with HTTP redirecting traffic to HTTPS. This is an initial start. There needs to be additional configuration available here, but this unblocks myself and should allow others to be able to do the same with a basic setup.

I am open to feedback on how to pass the variables to the construct. I put them at the top-level, but I considered adding them to the applicationLoadBalancer object in the cdk options. 