### PR TITLE
Fix non functional template for Prisma

### DIFF
--- a/packages/create-sst/bin/presets/examples/prisma/templates/stacks/ExampleStack.ts
+++ b/packages/create-sst/bin/presets/examples/prisma/templates/stacks/ExampleStack.ts
@@ -3,48 +3,56 @@ import fs from "fs";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Api, StackContext } from "sst/constructs";
 
-export function ExampleStack({ stack, app }: StackContext) {
-  if (!app.local) {
-    // Create a layer for production
-    // This saves shipping Prisma binaries once per function
-    const layerPath = ".sst/layers/prisma";
+const prismaDatabaseLayerPath = "./.sst/layers/prisma";
 
-    // Clear out the layer path
-    fs.removeSync(layerPath, { force: true, recursive: true });
-    fs.mkdirSync(layerPath, { recursive: true });
+function preparePrismaLayerFiles() {
+  // Remove any existing layer path data
+  fs.rmSync(prismaDatabaseLayerPath, { force: true, recursive: true });
 
-    // Copy files to the layer
-    const toCopy = [
-      "node_modules/.prisma",
-      "node_modules/@prisma/client",
-      "node_modules/prisma/build",
-    ];
-    for (const file of toCopy) {
-      fs.copySync(file, path.join(layerPath, "nodejs", file), {
-        // Do not include binary files that aren't for AWS to save space
-        filter: (src) => !src.endsWith("so.node") || src.includes("rhel"),
-      });
-    }
-    const prismaLayer = new lambda.LayerVersion(stack, "PrismaLayer", {
-      code: lambda.Code.fromAsset(path.resolve(layerPath)),
+  // Create a fresh new layer path
+  fs.mkdirSync(prismaDatabaseLayerPath, { recursive: true });
+
+  // Prisma folders to retrieve the client and the binaries from
+  const prismaFiles = [
+    "node_modules/@prisma/client",
+    "node_modules/prisma/build",
+  ];
+
+  for (const file of prismaFiles) {
+    fs.cpSync(file, path.join(prismaDatabaseLayerPath, "nodejs", file), {
+      // Do not include binary files that aren't for AWS to save space
+      filter: (src) =>
+        !src.endsWith("so.node") ||
+        src.includes("rhel") ||
+        src.includes("linux-arm64"),
+      recursive: true,
     });
-
-    // Add to all functions in this stack
-    stack.addDefaultFunctionLayers([prismaLayer]);
   }
+}
+
+export function ExampleStack({ stack, app }: StackContext) {
+  preparePrismaLayerFiles();
+
+  // Creation of the Prisma layer
+  const prismaLayer = new lambda.LayerVersion(stack, "PrismaLayer", {
+    code: lambda.Code.fromAsset(path.resolve(prismaDatabaseLayerPath)),
+  });
+
+  // Add the Prisma layer to all functions in this stack
+  stack.addDefaultFunctionLayers([prismaLayer]);
 
   const api = new Api(stack, "Api", {
     defaults: {
       function: {
+        runtime: "nodejs20.x",
         environment: {
-          DATABASE_URL: app.local
-            ? "mysql://root@localhost:3306/test"
-            : "mysql://production-url",
+          // You can also use the Config.DATABASE_URL object here
+          // or the bind functionality instead of environment props, i.e. bind: [DATABASE_URL],
+          DATABASE_URL: process.env.DATABASE_URL!,
         },
         nodejs: {
           esbuild: {
-            // Only reference external modules when deployed
-            externalModules: app.local ? [] : ["@prisma/client", ".prisma"],
+            external: ["@prisma/client", ".prisma"],
           },
         },
       },


### PR DESCRIPTION
Fixed:
- update Prisma files location (remove the obsolete one - .prisma)
- rmSync and cpSync instead of removeSync and copySync
- add 'recursive' option while copying prisma files to avoid the error 'Path is a directory: cp returned EISDIR'
- remove the local only deployment to make it work with 'sst dev' mode
- load database URL from .env instead of hard coded one
- added the "linux-arm64" architecture if you are using AWS Graviton 2 (source: https://www.prisma.io/docs/orm/prisma-client/deployment/serverless/deploy-to-aws-lambda)
Some of the updates above are based on this repo: https://github.com/geauser/sst-prisma-example
Tested OK with Node 20 LTS.