### PR TITLE
cli/types await stacks call on types codegen

### DIFF
--- a/packages/sst/src/cli/commands/types.ts
+++ b/packages/sst/src/cli/commands/types.ts
@@ -29,7 +29,7 @@ export const types = (program: Program) =>
           name: project.config.name,
           region: project.config.region,
         });
-        sstConfig.stacks(app);
+        await sstConfig.stacks(app);
         Colors.line(
           Colors.success(`✔ `),
           `Types generated in ${path.resolve(project.paths.out, "types")}`


### PR DESCRIPTION
Fixes an issue where types would not be generated for an async app/stacks