### PR TITLE
update open-next version in NextjsSite construct

### DIFF
--- a/.changeset/empty-chairs-taste.md
+++ b/.changeset/empty-chairs-taste.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+NextjsSite: update to OpenNext 2.3.7

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -162,7 +162,7 @@ export interface NextjsSiteProps extends Omit<SsrSiteProps, "nodejs"> {
 }
 
 const LAYER_VERSION = "2";
-const DEFAULT_OPEN_NEXT_VERSION = "2.3.5";
+const DEFAULT_OPEN_NEXT_VERSION = "2.3.7";
 const DEFAULT_CACHE_POLICY_ALLOWED_HEADERS = [
   "accept",
   "rsc",


### PR DESCRIPTION
This PR is to bump the version of open-next to fix the recent issues in NextJS as discussed here: [500 error in console from Images](https://discord.com/channels/983865673656705025/1214865068550918215)

New version of open-next to use: **2.3.7**