### PR TITLE
modified render options to add cookies

### DIFF
--- a/packages/astro-sst/src/entrypoint.ts
+++ b/packages/astro-sst/src/entrypoint.ts
@@ -84,6 +84,7 @@ export function createExports(
       const renderOptions: RenderOptions = {
         routeData,
         clientAddress: internalEvent.headers['x-forwarded-for'] || internalEvent.remoteAddress,
+        addCookieHeader:true
       }
 
       debug("renderOptions", renderOptions);
@@ -127,6 +128,7 @@ export function createExports(
     const renderOptions: RenderOptions = {
       routeData,
       clientAddress: internalEvent.headers['x-forwarded-for'] || internalEvent.remoteAddress,
+      addCookieHeader:true
     }
 
     debug("renderOptions", renderOptions);

--- a/packages/astro-sst/src/lib/event-mapper.ts
+++ b/packages/astro-sst/src/lib/event-mapper.ts
@@ -156,7 +156,7 @@ export async function convertTo({
     [
       ...splitCookiesString(response.headers.getSetCookie() ?? undefined),
       ...(appCookies ?? []),
-    ],
+    ].filter((cookie,index,array) => array.indexOf(cookie) === index),
     { decodeValues: false, map: false, silent: true }
   );
 


### PR DESCRIPTION
cookies that were set with the  `Astro.cookie.set()` method were not passed on to the CloudflareResult. and some cookies were also duplicated before they were converted into specific AWS Responses