### PR TITLE
Docs: Fix typo in customDomain for SvelteKitSite and SolidStartSite

### DIFF
--- a/www/docs/constructs/SolidStartSite.about.md
+++ b/www/docs/constructs/SolidStartSite.about.md
@@ -491,7 +491,7 @@ import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
 
 new SolidStartSite(stack, "Site", {
   path: "my-solid-app/",
-  cutomDomain: {
+  customDomain: {
     isExternalDomain: true,
     domainName: "my-app.com",
     cdk: {

--- a/www/docs/constructs/SvelteKitSite.about.md
+++ b/www/docs/constructs/SvelteKitSite.about.md
@@ -546,7 +546,7 @@ import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
 
 new SvelteKitSite(stack, "Site", {
   path: "my-svelte-app/",
-  cutomDomain: {
+  customDomain: {
     isExternalDomain: true,
     domainName: "my-app.com",
     cdk: {


### PR DESCRIPTION
Discovered a typo in the documentation when implementing custom domains for a SvelteKitSite. It's a hard typo to spot, search for similar typos and found the same typo in SolidStartSite.