### PR TITLE
fix[astro]: correct endless route matching loop

### DIFF
--- a/.changeset/moody-pigs-bake.md
+++ b/.changeset/moody-pigs-bake.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Astro: fixes infinite loop during deployment caused by Astro plugins

--- a/packages/sst/src/constructs/util/astroRouteCompressor.ts
+++ b/packages/sst/src/constructs/util/astroRouteCompressor.ts
@@ -38,7 +38,11 @@ function buildRouteTree(routes: BuildMetaConfig["routes"], level = 0) {
     ) {
       delete routeTree.branches[key];
     } else if (branch.nodes.length > 1) {
-      routeTree.branches[key] = buildRouteTree(branch.nodes, level + 1);
+      const deduplicatedNodes = branch.nodes.filter(
+        (node, index, arr) =>
+          arr.findIndex((n) => n.pattern === node.pattern) === index
+      );
+      routeTree.branches[key] = buildRouteTree(deduplicatedNodes, level + 1);
       branch.nodes = [];
     }
   }


### PR DESCRIPTION
Before calling recursive tree function, check if remaining nodes have duplicate patterns and if so, only keep the first instance (since the default behavior is to accept the first matched route).

This implementation assumes that routes which cause infinite looping will have identical patterns, but that's not strictly true as the actual branching occurs when the capture groups have been removed from the pattern, so two routes could have slightly different patterns due to one having a capture and the other not. I don't foresee this ever occurring given Astro's current implementation but it's possible a plugin author could be really sloppy and write a pattern which matches but doesn't extract the slug in which case this would cause issues. If that happens, make the plugin author fix their code 😜. _(It could be handled by reducing the dedup function to use the capture group extracted patterns for matching but it complicates the code a bit more than I think is necessary)_

Resolves #3707