### PR TITLE
docs: update `About us` footer link

### DIFF
--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -143,7 +143,7 @@ module.exports = {
             },
             {
               label: "About us",
-              href: "https://sst.dev/about.html",
+              href: "https://sst.dev/about/",
             },
             {
               label: "Contact us",


### PR DESCRIPTION
Fix 404 `About us` footer link.