### PR TITLE
astro-fix: prevent dead-end nodes from resulting in 404

### DIFF
--- a/.changeset/late-bottles-deny.md
+++ b/.changeset/late-bottles-deny.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Astro: fixes 404s caused by dead in route branches in CF routing

--- a/packages/sst/src/constructs/AstroSite.ts
+++ b/packages/sst/src/constructs/AstroSite.ts
@@ -52,9 +52,8 @@ export class AstroSite extends SsrSite {
   var routeData = ${getStringifiedRouteTree(routes)};
   var findFirstMatch = (matches) => Array.isArray(matches[0]) ? findFirstMatch(matches[0]) : matches;
   var findMatches = (path, routeData) => routeData.map((route) => route[0].test(path) ? Array.isArray(route[1]) ? findMatches(path, route[1]) : route : null).filter(route => route !== null && route.length > 0);
-  
   var matchedRoute = findFirstMatch(findMatches(request.uri, routeData));
-  if (matchedRoute) {
+  if (matchedRoute[0]) {
     if (!matchedRoute[1] && !/^.*\\.[^\\/]+$/.test(request.uri)) {
       ${
         pageResolution === "file"

--- a/packages/sst/src/constructs/AstroSite.ts
+++ b/packages/sst/src/constructs/AstroSite.ts
@@ -50,12 +50,10 @@ export class AstroSite extends SsrSite {
   }: BuildMetaConfig) {
     return `
   var routeData = ${getStringifiedRouteTree(routes)};
-  var findMatch = (path, routeData) => {
-    var match = routeData.find((route) => route[0].test(path));
-    return match && Array.isArray(match[1]) ? findMatch(path, match[1]) : match;
-  };
-    
-  var matchedRoute = findMatch(request.uri, routeData);
+  var findFirstMatch = (matches) => Array.isArray(matches[0]) ? findFirstMatch(matches[0]) : matches;
+  var findMatches = (path, routeData) => routeData.map((route) => route[0].test(path) ? Array.isArray(route[1]) ? findMatches(path, route[1]) : route : null).filter(route => route !== null && route.length > 0);
+  
+  var matchedRoute = findFirstMatch(findMatches(request.uri, routeData));
   if (matchedRoute) {
     if (!matchedRoute[1] && !/^.*\\.[^\\/]+$/.test(request.uri)) {
       ${


### PR DESCRIPTION
Prevents route branches that don't have a matching final node from resulting in a `null` match when a viable match exists in a lower branch.

Works best when combined with Astro's experimental `globalRoutePriority` feature ( https://github.com/withastro/astro/pull/9439) which avoids other common routing issues by prioritizing matching for plugins as well.

Resolves #3717 