### PR TITLE
Fix cacheTo Function/container prop

### DIFF
--- a/.changeset/chilled-laws-push.md
+++ b/.changeset/chilled-laws-push.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Fix cacheTo Function/container prop

--- a/packages/sst/src/constructs/Service.ts
+++ b/packages/sst/src/constructs/Service.ts
@@ -1293,8 +1293,8 @@ export class Service extends Construct implements SSTConstruct {
                           ([pk, pv]) => `${pk}=${pv}`
                         )
                       : []
-                    ).join(","),
-                  ],
+                    )
+                  ].join(","),,
               ]
             : []),
           this.props.path,

--- a/packages/sst/src/runtime/handlers/container.ts
+++ b/packages/sst/src/runtime/handlers/container.ts
@@ -284,8 +284,8 @@ export const useContainerHandler = (): RuntimeHandler => {
                               input.props.container?.cacheTo?.params
                             ).map(([pk, pv]) => `${pk}=${pv}`)
                           : []
-                        ).join(","),
-                      ],
+                        )
+                      ].join(","),,
                   ]
                 : []),
               `.`,
@@ -346,8 +346,8 @@ export const useContainerHandler = (): RuntimeHandler => {
                               input.props.container?.cacheTo?.params
                             ).map(([pk, pv]) => `${pk}=${pv}`)
                           : []
-                        ).join(","),
-                      ],
+                        )
+                      ].join(","),,
                   ]
                 : []),
               `--platform ${platform}`,

--- a/packages/sst/test/constructs/Function.test.ts
+++ b/packages/sst/test/constructs/Function.test.ts
@@ -257,7 +257,7 @@ test("runtime: container: props", async () => {
         { type: "inline" },
         { type: "local", params: { src: ".", mode: "max" } },
       ],
-      cacheTo: { type: "inline" },
+      cacheTo: { type: "local", params: { dest: ".", mode: "max"} },
     },
   });
   await app.finish();


### PR DESCRIPTION
# Summary

Small fix for my earlier PR https://github.com/sst/sst/pull/3651 that added `buildSsh`, `cacheTo`, `cacheFrom` properties to Functions/containers

My `.join(",")` was in the wrong place, and was joining the characters of each string in the array instead of the array of strings which produced Docker build arguments like 

`--cache-to=type=local,d,e,s,t,=,.,,,m,o,d,e,=,m,a,x`

## Tests

I updated the test I added to include additional params in the `cacheTo` object to verify things now work as expected. 

**Before**
```bash
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

FAIL  test/constructs/Function.test.ts > runtime: container: props
Error: Failed to build function "test/constructs/container-function"
Error: Command failed: docker build -t sst-build:c8ed9dbe9a800c218512b749c670e088ecf3a53842 --cache-from=type=inline --cache-from=type=local,src=.,mode=max --cache-to=type=local,d,e,s,t,=,.,,,m,o,d,e,=,m,a,x --platform linux/amd64 .
ERROR: invalid value d

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯

Test Files  1 failed (1)
    Tests  1 failed | 109 passed (110)
  Start at  18:14:18
  Duration  11.54s (transform 366ms, setup 0ms, collect 1.89s, tests 9.41s, environment 0ms, prepare 60ms)
```

**After**
```
Test Files  1 passed (1)
   Tests  110 passed (110)
  Start at  18:15:21
  Duration  11.88s (transform 352ms, setup 0ms, collect 1.92s, tests 9.73s, environment 0ms, prepare 59ms)   
```