### PR TITLE
Update WebSocketApi.about.md

### DIFF
--- a/www/docs/constructs/WebSocketApi.about.md
+++ b/www/docs/constructs/WebSocketApi.about.md
@@ -306,10 +306,10 @@ export const handler = WebSocketApiHandler(async () => {
 
 ```
 
-And to connect, remember to set your Authorization Header. Here's an example using [wscat](https://www.npmjs.com/package/wscat).
+And to connect, remember to set your Sec-WebSocket-Protocol Header. Here's an example using browser [WebSocket API](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API).
 
-```sh
-$ wscat -c wss://abcdef123.execute-api.us-west-2.amazonaws.com/production -H "authorization:Bearer jwt-from-auth"
+```javascript
+const connectedAndAuthorizedWebSocket = new WebSocket(websocketApiUrl, authTokenFromSession)
 ```
 
 ### Access log


### PR DESCRIPTION
I tried to use the SST Auth `useSession` with the websocket api and could not get it to work. Had to read the source code. This is an update to the docs showing the example which worked for me.

See line 33-38 of `st/src/node/auth/session.ts`