### PR TITLE
- Update Open Next Version for NextJSSite construct

### DIFF
--- a/.changeset/five-hounds-draw.md
+++ b/.changeset/five-hounds-draw.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+NextjsSite: update OpenNext version to 2.3.8

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -162,7 +162,7 @@ export interface NextjsSiteProps extends Omit<SsrSiteProps, "nodejs"> {
 }
 
 const LAYER_VERSION = "2";
-const DEFAULT_OPEN_NEXT_VERSION = "2.3.7";
+const DEFAULT_OPEN_NEXT_VERSION = "2.3.8";
 const DEFAULT_CACHE_POLICY_ALLOWED_HEADERS = [
   "accept",
   "rsc",


### PR DESCRIPTION
- Update Open Next Version for NextJSSite construct to 2.3.8: This is to include the fix included in https://github.com/sst/open-next/pull/387