### PR TITLE
Quickstart: Update import for vite / SvelteKit 2 migration

### DIFF
--- a/examples/quickstart-sveltekit/svelte.config.js
+++ b/examples/quickstart-sveltekit/svelte.config.js
@@ -1,5 +1,5 @@
 import adapter from "svelte-kit-sst";
-import { vitePreprocess } from "@sveltejs/kit/vite";
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {


### PR DESCRIPTION
The quickstart example code does not have the updated import for vitePreprocess. This pull request fixes that.