### PR TITLE
NextjsSite: Add fallback for custom Cloudfront error responses

### DIFF
--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -821,7 +821,7 @@ export abstract class SsrSite extends Construct implements SSTConstruct {
                 }, {} as Record<string, BehaviorOptions>),
               ...(cdk?.distribution?.additionalBehaviors || {}),
             },
-            errorResponses: plan.errorResponses ?? cdk?.distribution.errorResponses,
+            errorResponses: plan.errorResponses ?? cdk?.distribution?.errorResponses,
           },
         },
       });

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -821,7 +821,7 @@ export abstract class SsrSite extends Construct implements SSTConstruct {
                 }, {} as Record<string, BehaviorOptions>),
               ...(cdk?.distribution?.additionalBehaviors || {}),
             },
-            errorResponses: plan.errorResponses,
+            errorResponses: plan.errorResponses ?? cdk?.distribution.errorResponses,
           },
         },
       });


### PR DESCRIPTION
This change resolves an issue where defined errorResponse pages are not added to the Cloudfront deployment for a NextjsSite.

Run a deployment with the following `errorResponses` and you will see the error pages in Cloudfront.

```javascript
  const site = new NextjsSite(stack, 'MySite', {
    customDomain: setCustomDomain(stack),
    cdk: {
      distribution: {
        defaultBehavior: {
          viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
          allowedMethods: AllowedMethods.ALLOW_ALL,
        },
        errorResponses: [
          {
            httpStatus: 400,
            responseHttpStatus: 200,
            responsePagePath: '/index.html',
            ttl: Duration.minutes(10),
          }
        ],
        httpVersion: HttpVersion.HTTP2_AND_3,
      },
    },
  });
```