### PR TITLE
add toolkitStackName to bootstrapping docs

### DIFF
--- a/www/docs/advanced/bootstrapping.md
+++ b/www/docs/advanced/bootstrapping.md
@@ -89,6 +89,7 @@ There are two ways to customize the bootstrapping resources.
           qualifier: "my-team",
           fileAssetsBucketName: "my-team-CDKToolkit",
           customPermissionsBoundary: "my-team-pb",
+          toolkitStackName: "custom-cdk-bootstrap-stack-name",
         }
       }
     },


### PR DESCRIPTION
I spent a long time trying to figure out how to customise the name of the CDK bootstrap stack. Turns out it's quite easy.