### PR TITLE
Explicitly target glibc 2.26 for rust on Amazon Linux 2

### DIFF
--- a/packages/sst/src/runtime/handlers/rust.ts
+++ b/packages/sst/src/runtime/handlers/rust.ts
@@ -95,6 +95,9 @@ export const useRustHandler = (): RuntimeHandler => {
               "build",
               "--release",
               ...(input.props.architecture === "arm_64" ? ["--arm64"] : []),
+              // Explicitly target glibc 2.26 for Amazon Linux 2
+              // https://repost.aws/questions/QUrXOioL46RcCnFGyELJWKLw/glibc-2-27-on-amazon-linux-2
+              `--target ${input.props.architecture === "arm_64" ? "aarch64" : "x86_64"}-unknown-linux-gnu.2.26`,
               `--bin ${parsed.name}`,
             ].join(" "),
             {


### PR DESCRIPTION
Hi there! I recently started running into errors like this for the rust lambda I have deployed through sst:

> /var/task/bootstrap: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /var/task/bootstrap)

Did a bit of digging and it seems like this is because SST deploys rust functions to Amazon Linux 2, which only supports glibc 2.26: https://repost.aws/questions/QUrXOioL46RcCnFGyELJWKLw/glibc-2-27-on-amazon-linux-2

I suspect the target probably changed at some point seemingly randomly due to upgrades on the CI builder fleet?

So I've added a target flag in this PR to ensure we target glibc2.26 regardless of build environment.

I published this change (without the arm64 branch) in a separate package at https://www.npmjs.com/package/@lewisl9029/sst, gave it a try myself, and it seems to have resolved these errors. Please note that although I added an arm64 branch in the code, I've only tested this with an x86_64 lambda.

Looks like a few folks have had [similar](https://discord.com/channels/983865673656705025/1231555726342885487/1231555726342885487) [issues](https://discord.com/channels/983865673656705025/1168643741603602523/1168651959285317773), so I figured I'd try to get this merged. :)

Cheers!