### PR TITLE
add postgresq13.12 as an option - RDS.ts

### DIFF
--- a/packages/sst/src/constructs/RDS.ts
+++ b/packages/sst/src/constructs/RDS.ts
@@ -48,6 +48,7 @@ export interface RDSProps {
     | "mysql8.0"
     | "postgresql11.13"
     | "postgresql11.16"
+    | "postgresql13.12"
     | "postgresql13.9"
     | "postgresql14.10"
     | "postgresql15.5"
@@ -442,6 +443,10 @@ export class RDS extends Construct implements SSTConstruct {
       return DatabaseClusterEngine.auroraPostgres({
         version: AuroraPostgresEngineVersion.VER_11_16,
       });
+    } else if (engine === "postgresql13.12") {
+      return DatabaseClusterEngine.auroraPostgres({
+        version: AuroraPostgresEngineVersion.VER_13_12,
+      });
     } else if (engine === "postgresql13.9") {
       return DatabaseClusterEngine.auroraPostgres({
         version: AuroraPostgresEngineVersion.VER_13_9,
@@ -461,7 +466,7 @@ export class RDS extends Construct implements SSTConstruct {
     }
 
     throw new Error(
-      `The specified "engine" is not supported for sst.RDS. Only mysql5.6, mysql5.7, postgresql11.13, postgresql11.16, and postgres13.9 engines are currently supported.`
+      `The specified "engine" is not supported for sst.RDS. Only mysql5.6, mysql5.7, postgresql11.13, postgresql11.16, postgresql13.12 and postgresql13.9 engines are currently supported.`
     );
   }
 


### PR DESCRIPTION
There are cases of people that have deployed postgresql11.13, which now appears as deprecated, and can't be deployed anymore. For those cases, they can modify by rds console to version 13.12 and the deploy postgresql13.12. To do that we need to add this option.