### PR TITLE
fix: Cloudwatch logs already exists

### DIFF
--- a/.changeset/old-walls-marry.md
+++ b/.changeset/old-walls-marry.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Fix an error with trying to re-create the Cloudwatch log group on deployment

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -170,7 +170,7 @@ const DEFAULT_CACHE_POLICY_ALLOWED_HEADERS = [
   "next-router-state-tree",
   "next-url",
   "x-prerender-bypass",
-  "x-prerender-revalidate"
+  "x-prerender-revalidate",
 ];
 
 type NextjsSiteNormalizedProps = NextjsSiteProps & SsrSiteNormalizedProps;
@@ -245,7 +245,7 @@ export class NextjsSite extends SsrSite {
     this.handleMissingSourcemap();
 
     if (this.isPerRouteLoggingEnabled()) {
-      //this.disableDefaultLogging();
+      this.disableDefaultLogging();
       this.uploadSourcemaps();
     }
 


### PR DESCRIPTION
We have noticed the following error inside of our logs whenever a deploy is performed.

Field | Value
-- | --
`@ingestionTime` | 1715805990471
`@log` | 938102389012:/aws/lambda/justin-dash-ClientPortalS-siteServerFunction6DFA6F-v9eI1kIpu2pj
`@logStream` | 2024/05/15/[$LATEST]a90ddcb051994e2fa16661c9feb76aa8
`@message` | 2024/05/15 20:46:30 operation error CloudWatch Logs: CreateLogGroup, https response error StatusCode: 400, RequestID: 3015de96-71ee-4362-8753-98923266f001, ResourceAlreadyExistsException: The specified log group already exists
`@timestamp` | 1715805990312

After investigation, it looks like it's because the defaultLogging was commented out. 