### PR TITLE
[Service] Add support for defining target build stage when running docker build

### DIFF
--- a/packages/sst/src/constructs/Service.ts
+++ b/packages/sst/src/constructs/Service.ts
@@ -458,6 +458,19 @@ export interface ServiceProps {
      * ```
      */
     cacheTo?: ServiceContainerCacheProps;
+    /**
+     * Target build stage to pass to the docker build command.
+     * @default No --target flag is passed to the build command
+     * @example
+     * ```js
+     * {
+     *   build: {
+     *     target: 'prod'
+     *   }
+     * }
+     * ```
+     */
+    target?: string;
   };
   dev?: {
     /**
@@ -1292,11 +1305,11 @@ export class Service extends Construct implements SSTConstruct {
                       ? Object.entries(build?.cacheTo?.params).map(
                           ([pk, pv]) => `${pk}=${pv}`
                         )
-                      : []
-                    )
-                  ].join(","),,
+                      : []),
+                  ].join(","),
               ]
             : []),
+          ...(build?.target ? [`--target ${build.target}`] : []),
           this.props.path,
         ].join(" "),
         {

--- a/www/docs/constructs/Service.about.md
+++ b/www/docs/constructs/Service.about.md
@@ -294,6 +294,18 @@ new Service(stack, "MyService", {
 });
 ```
 
+Target build stage can also be passed in to the docker build command.
+
+```js
+new Service(stack, "MyService", {
+  path: "./service",
+  port: 3000,
+  build: {
+    target: "prod"
+  }
+});
+```
+
 ### Configuring log retention
 
 The Service construct creates a CloudWatch log group to store the logs. By default, the logs are retained indefinitely. You can configure the log retention period like this:


### PR DESCRIPTION
Docker build supports multi stage builds using the "--target" option. This PR adds support for defining a target when running Docker build for the Service construct.