### PR TITLE
Add missing dotnet8 bootstrap support copy command

### DIFF
--- a/.changeset/sixty-snakes-admire.md
+++ b/.changeset/sixty-snakes-admire.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Add missing dotnet8 bootstrap support copy command

--- a/packages/sst/build.mjs
+++ b/packages/sst/build.mjs
@@ -162,6 +162,7 @@ await Promise.all(
     "java-runtime",
     "dotnet31-bootstrap",
     "dotnet6-bootstrap",
+    "dotnet8-bootstrap",
     "nixpacks",
     "service-dev-function",
   ].map((dir) =>


### PR DESCRIPTION
Fixes local issue when running on dotnet8.

This change should have been included in #3734.
