### PR TITLE
misc(rds): make migrator methods protected

### DIFF
--- a/.changeset/short-garlics-teach.md
+++ b/.changeset/short-garlics-teach.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+misc(rds): make migrator methods protected

--- a/packages/sst/src/constructs/RDS.ts
+++ b/packages/sst/src/constructs/RDS.ts
@@ -415,7 +415,7 @@ export class RDS extends Construct implements SSTConstruct {
     return props;
   }
 
-  private validateMigrationsFileExists(migrations: string) {
+  protected validateMigrationsFileExists(migrations: string) {
     if (!fs.existsSync(migrations))
       throw new Error(
         `Cannot find the migrations in "${path.resolve(migrations)}".`
@@ -527,7 +527,7 @@ export class RDS extends Construct implements SSTConstruct {
     return cdk!.cluster as ServerlessCluster;
   }
 
-  private createMigrationsFunction(migrations: string) {
+  protected createMigrationsFunction(migrations: string) {
     const { engine, defaultDatabaseName } = this.props;
     const app = this.node.root as App;
 
@@ -577,7 +577,10 @@ export class RDS extends Construct implements SSTConstruct {
       "rds-migrator/index.handler";
   }
 
-  private createMigrationCustomResource(migrations: string) {
+  protected createMigrationCustomResource(
+    migrations: string,
+    database?: string
+  ) {
     const app = this.node.root as App;
 
     // Create custom resource handler
@@ -614,7 +617,7 @@ export class RDS extends Construct implements SSTConstruct {
           app.mode === "dev" ? undefined : this.migratorFunction?.functionName,
         UserUpdateFunction:
           app.mode === "dev" ? undefined : this.migratorFunction?.functionName,
-        UserParams: JSON.stringify({}),
+        UserParams: JSON.stringify({ database }),
         MigrationsHash: hash,
       },
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -566,7 +566,7 @@ importers:
         specifier: ^5.3.1
         version: 5.3.1
       astro-sst:
-        specifier: 2.42.0
+        specifier: 2.43.0
         version: link:../astro-sst
       async:
         specifier: ^3.2.4


### PR DESCRIPTION
## Summary

This PR makes the `RDS` construct's `validateMigrationsFileExists` `createMigrationsFunction` and `createMigrationCustomResource` functions `protected`, and therefore accessible to a subclass.

## Context

To speed our deployments, our team would like to start sharing one RDS instance amongst all of our PR environments. We were planning on following the SST guide to [import an existing cluster](https://docs.sst.dev/constructs/RDS#import-existing-rds-serverless-v1-cluster).

However, all PR environments cannot share the same database as that would lead to conflicts. Therefore, our plan was to do the following:
1. Load the shared RDS instance
2. Create a [`Script`](https://docs.sst.dev/constructs/Script) whose `onCreate` creates a new database from the `defaultDatabaseName`, i.e. `CREATE DATABASE pr1234` and whose `onDelete` drops the PR database
3. Run the migration functions on the new database

```
class PullRequestRds extends Rds {
  constructor(scope: Construct, id: string, props: RdsProps) {
    const app = scope.node.root as App;

    const { migrations, ...rest } = props;
    super(construct, id, rest);
    this.validateMigrationsFileExists(migrations);
    this.createMigrationsFunction(migrations);
    // Assume that we've already run the `Script` from step 2
    this.createMigrationCustomResource(migrations, app.stage);
  }
}
```

In the example above, `props` contains the `cluster` and `secret` information needed to load the existing cluster. We also accept a value for `migrations` but we notably don't pass it to the superclass constructor because we don't want to run the migrations on the `defaultDatabaseName`, but rather on the new target database. I've also updated the `createMigrationCustomResource` function to accept an additional optional argument to use as the [`database` name instead of the `defaultDatabaseName`](https://github.com/sst/sst/blob/master/packages/sst/support/rds-migrator/index.mjs#L16)

At present, there's no way to invoke the migrator functions from outside of the class, hence this PR. 