### PR TITLE
fix: google and apple adapter

### DIFF
--- a/.changeset/great-moles-lie.md
+++ b/.changeset/great-moles-lie.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+fix: google and apple adapter

--- a/packages/sst/src/node/future/auth/adapter/apple.ts
+++ b/packages/sst/src/node/future/auth/adapter/apple.ts
@@ -3,7 +3,7 @@ import { BaseClient, generators, Issuer } from 'openid-client';
 
 import { useBody, useCookie, useDomainName, usePathParam, useResponse } from '../../../api/index.js';
 import { Adapter } from './adapter.js';
-import { OauthConfig, OauthBasicConfig } from './oauth.js';
+import { OauthBasicConfig } from './oauth.js';
 
 // This adapter support the OAuth flow with the response_mode "form_post" for now.
 // More details about the flow:
@@ -15,12 +15,16 @@ import { OauthConfig, OauthBasicConfig } from './oauth.js';
 
 let issuer: Issuer<BaseClient>;
 
+type AppleConfig = OauthBasicConfig & {
+  issuer?: Issuer
+}
+
 export const AppleAdapter =
   /* @__PURE__ */
-  (config: OauthConfig | OauthBasicConfig) => {
+  (config: AppleConfig) => {
 
     return async function () {
-      const doesConfigHasIssuer = ((config as OauthConfig).issuer) !== undefined
+      const doesConfigHasIssuer = config.issuer !== undefined
       if(!doesConfigHasIssuer && !issuer){
         issuer = await Issuer.discover("https://appleid.apple.com/.well-known/openid-configuration");
       }

--- a/packages/sst/src/node/future/auth/adapter/apple.ts
+++ b/packages/sst/src/node/future/auth/adapter/apple.ts
@@ -1,9 +1,9 @@
 import querystring from 'node:querystring';
-import {BaseClient, generators, Issuer} from 'openid-client';
+import { BaseClient, generators, Issuer } from 'openid-client';
 
 import { useBody, useCookie, useDomainName, usePathParam, useResponse } from '../../../api/index.js';
 import { Adapter } from './adapter.js';
-import { OauthConfig } from './oauth.js';
+import { OauthConfig, OauthBasicConfig } from './oauth.js';
 
 // This adapter support the OAuth flow with the response_mode "form_post" for now.
 // More details about the flow:
@@ -13,22 +13,17 @@ import { OauthConfig } from './oauth.js';
 // userinfo_endpoint are not included in the response.
 // await Issuer.discover("https://appleid.apple.com/.well-known/openid-configuration/");
 
-let realIssuer: Issuer<BaseClient>;
-
-const issuer = new Proxy({}, {
-  get: async function(target, prop: string){
-    if(!realIssuer){
-      realIssuer = await Issuer.discover("https://appleid.apple.com/.well-known/openid-configuration");
-    }
-    return realIssuer[prop];
-  }
-})
+let issuer: Issuer<BaseClient>;
 
 export const AppleAdapter =
   /* @__PURE__ */
-  (config: OauthConfig) => {
+  (config: OauthConfig | OauthBasicConfig) => {
 
     return async function () {
+      const doesConfigHasIssuer = ((config as OauthConfig).issuer) !== undefined
+      if(!doesConfigHasIssuer && !issuer){
+        issuer = await Issuer.discover("https://appleid.apple.com/.well-known/openid-configuration");
+      }
       const step = usePathParam("step");
       const callback = "https://" + useDomainName() + "/callback";
       console.log("callback", callback);


### PR DESCRIPTION
I keep getting `config.issuer.Client is not a constructor` (for example GoogleAdapter) in SST v^2.42.0.
In the previous version it does work SST v2.41.5.
I looked into the implementation and I think this `Proxy` for resolving issuers might not be working as expected.

[Discord](https://discord.com/channels/983865673656705025/1082462837710012508/1246779198132060192)