### PR TITLE
fix: obey runtime and memorySize configs in `NextjsSite`

### DIFF
--- a/.changeset/silly-cats-grow.md
+++ b/.changeset/silly-cats-grow.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+NextjsSite: respect runtime and memorySize configs

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -266,9 +266,9 @@ export class NextjsSite extends SsrSite {
         ...baseServerConfig,
         handler: fn.handler,
         bundle: path.join(sitePath, fn.bundle),
-        runtime: "nodejs18.x" as const,
+        runtime: this.props.runtime ?? ("nodejs18.x" as const),
         architecture: Architecture.ARM_64,
-        memorySize: 1536,
+        memorySize: this.props.memorySize ?? 1536,
         environment: {
           ...environment,
           ...baseServerConfig.environment,


### PR DESCRIPTION
Introduced in https://github.com/sst/sst/commit/96b99e08f3cfbbbdf9f25f920be73e368b0599d0