### PR TITLE
misc(auth): expose session.verify in non-future auth

### DIFF
--- a/.changeset/metal-spies-melt.md
+++ b/.changeset/metal-spies-melt.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+chore(auth): expose session.verify in non-future auth

--- a/packages/sst/src/node/auth/session.ts
+++ b/packages/sst/src/node/auth/session.ts
@@ -38,11 +38,7 @@ const SessionMemo = /* @__PURE__ */ Context.memo(() => {
   if (wsProtocol) token = wsProtocol.split(",")[0].trim();
 
   if (token) {
-    const jwt = createVerifier({
-      algorithms: ["RS512"],
-      key: getPublicKey(),
-    })(token);
-    return jwt;
+    return Session.verify(token);
   }
 
   return {
@@ -85,6 +81,30 @@ function create<T extends keyof SessionTypes>(input: {
     properties: input.properties,
   });
   return token as string;
+}
+
+/**
+ * Verifies a session token and returns the session data
+ *
+ * @example
+ * ```js
+ * Session.verify()
+ * ```
+ */
+function verify<T = SessionValue>(token: string) {
+  if (token) {
+    try {
+      const jwt = createVerifier({
+        algorithms: ["RS512"],
+        key: getPublicKey(),
+      })(token);
+      return jwt as T;
+    } catch (e) {}
+  }
+  return {
+    type: "public",
+    properties: {},
+  };
 }
 
 /**
@@ -153,6 +173,7 @@ export function parameter<T extends keyof SessionTypes>(input: {
 
 export const Session = {
   create,
+  verify,
   cookie,
   parameter,
 };


### PR DESCRIPTION
Essentially copies the implementation of `Session.verify` from `packages/sst/src/node/future/auth/session.ts` into `packages/sst/src/node/auth/session.ts` so that users of "current `Auth`" have the ability to manually validate/verify tokens too.

Closes https://github.com/sst/sst/issues/3724