### PR TITLE
fix: fix dockerfile build commands for python 3.12

### DIFF
--- a/.changeset/flat-mirrors-relax.md
+++ b/.changeset/flat-mirrors-relax.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+fix: fix dockerfile build commands for python 3.12

--- a/packages/sst/support/python-runtime/Dockerfile
+++ b/packages/sst/support/python-runtime/Dockerfile
@@ -4,6 +4,6 @@ ARG IMAGE=amazon/aws-sam-cli-build-image-python3.7
 FROM $IMAGE
 
 # Ensure rsync is installed
-RUN yum -q list installed rsync &>/dev/null || yum install -y rsync
+RUN yum -q list installed rsync &>/dev/null || yum install -y rsync || dnf repoquery --installed rsync &>/dev/null || dnf install -y rsync
 
 CMD [ "python" ]

--- a/packages/sst/support/python-runtime/Dockerfile.custom
+++ b/packages/sst/support/python-runtime/Dockerfile.custom
@@ -4,7 +4,7 @@ ARG IMAGE=amazon/aws-sam-cli-build-image-python3.7
 FROM $IMAGE
 
 # Ensure rsync is installed
-RUN yum -q list installed rsync &>/dev/null || yum install -y rsync
+RUN yum -q list installed rsync &>/dev/null || yum install -y rsync || dnf repoquery --installed rsync &>/dev/null || dnf install -y rsync
 
 # Upgrade pip (required by cryptography v3.4 and above, which is a dependency of poetry)
 RUN pip install --upgrade pip

--- a/packages/sst/support/python-runtime/Dockerfile.dependencies
+++ b/packages/sst/support/python-runtime/Dockerfile.dependencies
@@ -4,7 +4,7 @@ ARG IMAGE=amazon/aws-sam-cli-build-image-python3.7
 FROM $IMAGE
 
 # Ensure rsync is installed
-RUN yum -q list installed rsync &>/dev/null || yum install -y rsync
+RUN yum -q list installed rsync &>/dev/null || yum install -y rsync || dnf repoquery --installed rsync &>/dev/null || dnf install -y rsync
 
 # Upgrade pip (required by cryptography v3.4 and above, which is a dependency of poetry)
 RUN pip install --upgrade pip


### PR DESCRIPTION
I've applied the fix mentioned in this [Discord comment ](https://discord.com/channels/983865673656705025/1106622583589306408/1219562915477323826) by user **jlarmst**

When monkey patching my install of `node_modeules/sst` I am able to build successfully. For transparency I don't know if this is a "good" fix, but it's the only thing that makes Python 3.12 work for me.

<details><summary>Discord Comment</summary>
<p>

I’ve searched Discord and found at least two reports of errors with python 3.12
- https://discord.com/channels/983865673656705025/1212069025937367060/1212069025937367060
- https://discord.com/channels/983865673656705025/1190123642584051733/1190123642584051733
It is most definitely failing.  Python 3.12 uses amazonlinux:2023, which has replaced `yum` with `dnf`, causing this error:

```
 => ERROR [2/9] RUN yum -q list installed rsync &>/dev/null || yum instal  0.1s
------
 > [2/9] RUN yum -q list installed rsync &>/dev/null || yum install -y rsync:
0.080 /bin/sh: line 1: yum: command not found
------
Dockerfile.dependencies:7
--------------------
   5 |
   6 |     # Ensure rsync is installed
   7 | >>> RUN yum -q list installed rsync &>/dev/null || yum install -y rsync
   8 |
   9 |     # Upgrade pip (required by cryptography v3.4 and above, which is a dependency of poetry)
--------------------
ERROR: failed to solve: process "/bin/sh -c yum -q list installed rsync &>/dev/null || yum install -y rsync" did not complete successfully: exit code: 127

Error: docker exited with status 1
```
Instead, we could append the dnf command to rsync in the three python support files, if yum fails.  Something like:
`RUN yum -q list installed rsync &>/dev/null || yum install -y rsync || dnf repoquery --installed rsync &>/dev/null || dnf install -y rsync`

It is possible to temporarily patch using https://www.npmjs.com/package/patch-package

</p>
</details> 

