### PR TITLE
SSTBootstrap: Add description to bootstrap stack

### DIFF
--- a/.changeset/lemon-deers-eat.md
+++ b/.changeset/lemon-deers-eat.md
@@ -1,0 +1,6 @@
+---
+"sst": patch
+"@sst/docs": patch
+---
+
+SSTBootstrap: Add description to bootstrap stack

--- a/packages/sst/src/bootstrap.ts
+++ b/packages/sst/src/bootstrap.ts
@@ -42,6 +42,8 @@ import { lazy } from "./util/lazy.js";
 
 const CDK_STACK_NAME = "CDKToolkit";
 const SST_STACK_NAME = "SSTBootstrap";
+const SST_STACK_DESCRIPTION =
+  "This stack includes resources needed to deploy SST apps into this environment";
 const OUTPUT_VERSION = "Version";
 const OUTPUT_BUCKET = "BucketName";
 const LATEST_VERSION = "7.3";
@@ -113,7 +115,7 @@ async function loadCDKStatus() {
     }
 
     // Check CDK bootstrap stack is up to date
-    // note: there is no a programmatical way to get the minimal required version
+    // note: there is no a programmatic way to get the minimal required version
     //       of CDK bootstrap stack. We are going to hardcode it to 14 for now,
     //       which is the latest version as of CDK v2.62.2
     let version: number | undefined;
@@ -206,10 +208,12 @@ export async function bootstrapSST(cdkBucket: string) {
   // Create bootstrap stack
   const app = new App();
   const stackName = bootstrap?.stackName || SST_STACK_NAME;
+  const stackDescription = bootstrap?.stackDescription || SST_STACK_DESCRIPTION;
   const stack = new Stack(app, stackName, {
     env: {
       region,
     },
+    description: stackDescription,
     synthesizer: new DefaultStackSynthesizer({
       qualifier: cdk?.qualifier,
       bootstrapStackVersionSsmParameter: cdk?.bootstrapStackVersionSsmParameter,

--- a/packages/sst/src/project.ts
+++ b/packages/sst/src/project.ts
@@ -31,6 +31,7 @@ export interface ConfigOptions {
   bootstrap?: {
     useCdkBucket?: boolean;
     stackName?: string;
+    stackDescription?: string;
     bucketName?: string;
     tags?: Record<string, string>;
   };

--- a/www/docs/configuring-sst.md
+++ b/www/docs/configuring-sst.md
@@ -85,6 +85,7 @@ Here's the full list of config options that can be returned:
 - **`bootstrap`**
   - **`bucketName`** The name to use for the SST bootstrap bucket
   - **`stackName`** The name to use for the SST bootstrap stack
+  - **`stackDescription`** The description to use for the SST bootstrap stack
   - **`tags`** Tags to use for the SST bootstrap stack
   - **`useCdkBucket`** Use the S3 bucket created by the CDK bootstrap process instead of creating a new one
 - **`cdk`**


### PR DESCRIPTION
Seems weird that CDKToolkit stacks get a description by default but SSTBootstrap stacks do not. 

I have lost track of the amount of times a Devops guy has been tidying up and deleted my bootstrap stack. Would be nice to have a meaningful and customisable description to let them know not to delete it. 

CDK example below. 

<img width="286" alt="Screenshot 2024-07-17 at 10 06 33" src="https://github.com/user-attachments/assets/f5a86d94-5428-45d6-86a8-cd59eb9ea7dc">

