### PR TITLE
fix: query params with no values should be strings

### DIFF
--- a/.changeset/clean-kiwis-greet.md
+++ b/.changeset/clean-kiwis-greet.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+SsrSite: fix query params with no values should be strings

--- a/packages/sst/support/signing-function/helpers/queryStringToQueryParameterBag.ts
+++ b/packages/sst/support/signing-function/helpers/queryStringToQueryParameterBag.ts
@@ -14,7 +14,7 @@ export const queryStringToQueryParameterBag = (
     const value = split[1];
 
     if (query[key] === undefined || query[key] === null) {
-      query[key] = value ? decodeURIComponent(value) : null;
+      query[key] = value ? decodeURIComponent(value) : "";
       continue;
     }
 


### PR DESCRIPTION
This change fixes the aws v4 signature when query string params with no values are used. This lambda is used when the option `regional.enableServerUrlIamAuth = true` is set in `SsrSite` (in my case `RemixSite`).

For example, posting to Remix index routes hits an endpoint such as:

https://xxxxx.cloudfront.net/?_data=routes%2F_index&index=

This version of the URL works as expected following the change