### PR TITLE
ECS (Service): allow disabling default autoscaling

### DIFF
--- a/packages/sst/src/constructs/Service.ts
+++ b/packages/sst/src/constructs/Service.ts
@@ -1102,7 +1102,6 @@ export class Service extends Construct implements SSTConstruct {
       minCapacity: minContainers ?? 1,
       maxCapacity: maxContainers ?? 1,
     });
-
     scaling.scaleOnCpuUtilization("CpuScaling", {
       targetUtilizationPercent: cpuUtilization ?? 70,
       scaleOutCooldown: CdkDuration.seconds(300),

--- a/packages/sst/src/constructs/Service.ts
+++ b/packages/sst/src/constructs/Service.ts
@@ -1086,6 +1086,10 @@ export class Service extends Construct implements SSTConstruct {
     service: FargateService,
     target?: ApplicationTargetGroup
   ) {
+    if (this.props.scaling === null) {
+      return
+    }
+
     const {
       minContainers,
       maxContainers,
@@ -1098,6 +1102,7 @@ export class Service extends Construct implements SSTConstruct {
       minCapacity: minContainers ?? 1,
       maxCapacity: maxContainers ?? 1,
     });
+
     scaling.scaleOnCpuUtilization("CpuScaling", {
       targetUtilizationPercent: cpuUtilization ?? 70,
       scaleOutCooldown: CdkDuration.seconds(300),


### PR DESCRIPTION
Hi!
There's a tiny change i need to setup my ECS autoscaling. I need to scale it based on SQS metric, and i also don't want to scale based on default params (cpu, memory).
With this tiny change i can disable default autoscaling by explicitly set scaling to null (`scaling: null`) and then use 
`service.cdk.fargateService.autoScaleTaskCount()` to create any custom scaling scenarios i want. 
Thanks!