### PR TITLE
Switch npm install command to use `--omit=optional` not `--no-optional`

### DIFF
--- a/.changeset/cuddly-pugs-bow.md
+++ b/.changeset/cuddly-pugs-bow.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Function: use --omit=optional to skip installing optional deps

--- a/packages/sst/src/runtime/handlers/node.ts
+++ b/packages/sst/src/runtime/handlers/node.ts
@@ -258,7 +258,7 @@ export const useNodeHandler = (): RuntimeHandler => {
           const cmd = [
             "npm install",
             "--omit=dev",
-            "--no-optional",
+            "--omit=optional",
             "--force",
             "--platform=linux",
             input.props.architecture === "arm_64"


### PR DESCRIPTION
By default NPM will install optional dependencies, even if you include --no-optional.

```
npm warn config optional Use `--omit=optional` to exclude optional dependencies, or
npm warn config `--include=optional` to include them.
npm warn config
npm warn config       Default value does install optional deps unless otherwise omitted.
```

See https://docs.npmjs.com/cli/v10/commands/npm-install#omit