### PR TITLE
[SvelteKitSite construct] add basePath support into SvelteKitSite construct

### DIFF
--- a/.changeset/warm-carrots-yawn.md
+++ b/.changeset/warm-carrots-yawn.md
@@ -1,0 +1,6 @@
+---
+"sst": patch
+"@sst/docs": patch
+---
+
+SvelteKitSite: add basePath support

--- a/packages/sst/src/constructs/SvelteKitSite.ts
+++ b/packages/sst/src/constructs/SvelteKitSite.ts
@@ -9,6 +9,15 @@ export interface SvelteKitSiteProps extends SsrSiteProps {
    * @default false
    */
   edge?: boolean;
+
+  /**
+   * This specifies where your app is served from and allows the app to live on a non-root path.
+   * @example
+   * ```js
+   * basePath: '/onboarding'
+   * ```
+   */
+  basePath?: "" | `/${string}`;
 }
 
 type SvelteKitSiteNormalizedProps = SvelteKitSiteProps & SsrSiteNormalizedProps;
@@ -35,7 +44,8 @@ export class SvelteKitSite extends SsrSite {
   }
 
   protected plan() {
-    const { path: sitePath, edge } = this.props;
+    const { path: sitePath, edge, basePath: maybeBasePath = "" } = this.props;
+    const basePath = maybeBasePath ? `${maybeBasePath}/` : "";
     const serverDir = ".svelte-kit/svelte-kit-sst/server";
     const clientDir = ".svelte-kit/svelte-kit-sst/client";
     const prerenderedDir = ".svelte-kit/svelte-kit-sst/prerendered";
@@ -114,13 +124,13 @@ export class SvelteKitSite extends SsrSite {
           copy: [
             {
               from: clientDir,
-              to: "",
+              to: basePath,
               cached: true,
               versionedSubDir: "_app",
             },
             {
               from: prerenderedDir,
-              to: "",
+              to: basePath,
               cached: false,
             },
           ],
@@ -147,8 +157,8 @@ export class SvelteKitSite extends SsrSite {
               pattern: fs
                 .statSync(path.join(sitePath, clientDir, item))
                 .isDirectory()
-                ? `${item}/*`
-                : item,
+                ? `${basePath}${item}/*`
+                : `${basePath}${item}`,
               origin: "s3",
             } as const)
         ),

--- a/packages/sst/src/constructs/SvelteKitSite.ts
+++ b/packages/sst/src/constructs/SvelteKitSite.ts
@@ -11,13 +11,15 @@ export interface SvelteKitSiteProps extends SsrSiteProps {
   edge?: boolean;
 
   /**
-   * This specifies where your app is served from and allows the app to live on a non-root path.
+   * Configures the base path for the SvelteKit app.
+   * Base path allows the app to live on a non-root path. The base path must start, but not end with /.
+   * @default No base path
    * @example
    * ```js
-   * basePath: '/onboarding'
+   * basePath: '/docs'
    * ```
    */
-  basePath?: "" | `/${string}`;
+  basePath?: `/${string}`;
 }
 
 type SvelteKitSiteNormalizedProps = SvelteKitSiteProps & SsrSiteNormalizedProps;
@@ -44,8 +46,8 @@ export class SvelteKitSite extends SsrSite {
   }
 
   protected plan() {
-    const { path: sitePath, edge, basePath: maybeBasePath = "" } = this.props;
-    const basePath = maybeBasePath ? `${maybeBasePath}/` : "";
+    const { path: sitePath, edge, basePath: rawBasePath } = this.props;
+    const basePath = rawBasePath ? `/${rawBasePath}` : "";
     const serverDir = ".svelte-kit/svelte-kit-sst/server";
     const clientDir = ".svelte-kit/svelte-kit-sst/client";
     const prerenderedDir = ".svelte-kit/svelte-kit-sst/prerendered";

--- a/www/docs/constructs/SvelteKitSite.about.md
+++ b/www/docs/constructs/SvelteKitSite.about.md
@@ -560,6 +560,17 @@ Note that the certificate needs be created in the `us-east-1`(N. Virginia) regio
 
 Also note that you can also migrate externally hosted domains to Route 53 by [following this guide](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
 
+#### Configuring basePath
+
+```js {3}
+new SvelteKitSite(stack, "Site", {
+  path: "my-svelte-app/",
+  basePath: "/mount"
+});
+```
+
+A root-relative path that must start, but not end with / (e.g. /base-path), unless it is the empty string. This specifies where your app is served from and allows the app to live on a non-root [path](https://kit.svelte.dev/docs/configuration#paths).
+
 ### Configuring server function
 
 ```js {3-4}

--- a/www/docs/constructs/SvelteKitSite.about.md
+++ b/www/docs/constructs/SvelteKitSite.about.md
@@ -560,16 +560,14 @@ Note that the certificate needs be created in the `us-east-1`(N. Virginia) regio
 
 Also note that you can also migrate externally hosted domains to Route 53 by [following this guide](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
 
-#### Configuring basePath
+### Configuring base path
 
 ```js {3}
 new SvelteKitSite(stack, "Site", {
   path: "my-svelte-app/",
-  basePath: "/mount"
+  basePath: "/docs"
 });
 ```
-
-A root-relative path that must start, but not end with / (e.g. /base-path), unless it is the empty string. This specifies where your app is served from and allows the app to live on a non-root [path](https://kit.svelte.dev/docs/configuration#paths).
 
 ### Configuring server function
 


### PR DESCRIPTION
Addresses: https://github.com/sst/sst/issues/2964

Taking inspiration from https://github.com/sst/sst/pull/3613 and updating the behaviours and S3 copy paths.