### PR TITLE
Introducing SST Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <a href="https://sst.dev/discord"><img alt="Discord" src="https://img.shields.io/discord/983865673656705025?style=flat-square&label=Discord" /></a>
   <a href="https://www.npmjs.com/package/sst"><img alt="npm" src="https://img.shields.io/npm/v/sst.svg?style=flat-square" /></a>
   <a href="https://github.com/sst/sst/actions/workflows/build.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/sst/sst/build.yml?style=flat-square&branch=dev" /></a>
+  <a href="https://gurubase.io/g/sst"><img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20SST%20Guru-006BFF?style=flat-square" /></a>
 </p>
 
 ---


### PR DESCRIPTION
Hello Team,

This PR is a friendly notification that the [SST Guru](https://gurubase.io/g/sst) has been added to Gurubase. The SST Guru uses data from this repository and the [documentation](https://sst.dev/docs) to answer questions by leveraging the LLM.

Gurubase is a centralized, RAG-based learning and troubleshooting assistant platform. Each "Guru" is equipped with custom knowledge to answer user questions based on data collected for that tool. More information can be found in [this repo](https://github.com/getanteon/gurubase).

This PR updates the README to indicate that SST users can now ask questions to SST Guru. As shown in the [Used By](https://github.com/getanteon/gurubase?tab=readme-ov-file#used-by) section, over 100 open-source repositories currently showcase their Guru in their README.md.

By default, there are three possible actions:
1. If you dislike it, we can immediately disable SST Guru in Gurubase and remove this PR.
2. If you like it but don’t want to add it to the README, we can remove this PR or include it in another place you prefer.
3. If you’re happy with it, we can keep it as is and merge the PR.

Although this PR is created by the Gurubase Notifier account, the team monitors it and will answer any questions you may have.

**Note:** If you consider this PR a time-waster, apologize for the inconvenience. Developers often request us to create a Guru for the tools they use. Once we create it, we notify the maintainers to inform them and seek their approval.
